### PR TITLE
Add support for LINK

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ end_of_line = crlf
 [*.cs]
 # Analyzer severity
 dotnet_diagnostic.CA1031.severity  = none  # Do not catch general exception types
+dotnet_diagnostic.CA1032.severity  = none  # Implement standard exception constructors
 dotnet_diagnostic.CA1848.severity  = none  # Use the LoggerMessage delegates
 dotnet_diagnostic.CA2254.severity  = none  # Template should be a static expression
 dotnet_diagnostic.IDE0130.severity = none  # Namespace does not match folder structure

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,7 @@ end_of_line = crlf
 # Analyzer severity
 dotnet_diagnostic.CA1031.severity  = none  # Do not catch general exception types
 dotnet_diagnostic.CA1032.severity  = none  # Implement standard exception constructors
+dotnet_diagnostic.CA1819.severity  = none  # Properties should not return arrays
 dotnet_diagnostic.CA1848.severity  = none  # Use the LoggerMessage delegates
 dotnet_diagnostic.CA2254.severity  = none  # Template should be a static expression
 dotnet_diagnostic.IDE0130.severity = none  # Namespace does not match folder structure

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 The Hyphen .NET SDK is a .NET library that allows developers to easily integrate Hyphen features into their application, including:
 
 - [Secret Management Service](https://hyphen.ai/env) ("ENV")
+- [Short Code Service](https://hyphen.ai/link) ("Link")
 - [Geo Information Service](https://hyphen.ai/net-info) ("net-info")
 
 The library is compatible with .NET Standard 2.0 and .NET 8.
@@ -23,6 +24,10 @@ The library is compatible with .NET Standard 2.0 and .NET 8.
     - [Adding ENV](#adding-env)
     - [Configuring ENV](#configuring-env)
     - [Using ENV](#using-env)
+  - [Link (Short Code Service)](#link-short-code-service)
+    - [Adding Link](#adding-link)
+    - [Configuring Link](#configuring-link)
+    - [Using Link](#using-link)
   - [net-info (Geo Information Service)](#net-info-geo-information-service)
     - [Adding net-info](#adding-net-info)
     - [Configuring net-info](#configuring-net-info)
@@ -114,6 +119,7 @@ The service instance types (and their configuration options object) include:
 > Service  | Interface  | Options
 > ---------|------------|--------
 > ENV      | `IEnv`     | `EnvOptions`
+> Link     | `ILink`    | `LinkOptions`
 > net-info | `INetInfo` | `NetInfoOptions`
 
 For more information on these patterns, see the Microsoft documentation:
@@ -182,6 +188,95 @@ Method       | Description
 All functions have overloads with a `required` parameter, which can change them from returning `null` for missing/invalid values to throwing `ArgumentException` instead. The numeric functions also include overloads that allow passing `NumberStyles` and `IFormatProvider` to influence the parsing of the numbers.
 
 _Note that the `Get` functions on `IEnv` can be used to access any environment variable, not just the ones loaded from your `.env` files._
+
+## Link (Short Code Service)
+
+### Adding Link
+
+The Hyphen .NET SDK provides an `ILink` service interface which allows you to manage short code links and associated QR codes.
+
+Short code links allow you to provide a link from a domain you own to any other URL. Short code links can be more memorable and easier to read aloud than the longer, deeper links that they send the user to. These links are typically used in marketing materials and promotions.
+
+QR codes allow you to create a QR code that can be scanned which will send the user to your short code link. They can embed a logo in their center for customization.
+
+You can read more about Link:
+
+* [Website](https://hyphen.ai/link)
+* [Creating short links](https://docs.hyphen.ai/docs/create-short-link)
+* [Creating QR codes](https://docs.hyphen.ai/docs/create-a-qr-code)
+
+### Configuring Link
+
+The `LinkOptions` class has the following properties that can be used to configure Link:
+
+Property          | Description
+------------------|------------
+`ApiKey`          | Sets the API used to talk to Link (defaults to the value in environment variable `HYPHEN_API_KEY` if not set).
+`BaseUriTemplate` | Sets the URI template of the Link service (defaults to `https://api.hyphen.ai/api/organizations/{organizationId}/link/codes/`). When constructing the base URI, the service replaces the text `{organizationId}` with your organization ID.
+`OrganizationId`  | Sets the organization ID used to perform Link operations (defaults to the value in environment variable `HYPHEN_ORGANIZATION_ID` if not set).
+
+### Using Link
+
+The APIs for link are grouped into two categories: APIs which manage short code links, and APIs which manage QR codes.
+
+#### Short Code Link APIs
+
+The `ILink` interface contains the following APIs related to short code links:
+
+Method              | Description
+--------------------|------------
+`CreateShortCode`   | Creates a short code
+`DeleteShortCode`   | Deletes a short code
+`GetShortCode`      | Gets information about a specific short code
+`GetShortCodes`     | Gets a list of short codes that match optional search criteria
+`GetShortCodeStats` | Gets statistics about short code usage
+`GetTags`           | Gets the list of tags used by all short codes in your organization
+`UpdateShortCode`   | Updates a short code
+
+Several APIs return one or more `ShortCodeResult` instances, which include the following properties:
+
+Property       | Description
+---------------|------------
+`Code`         | The "code" portion of the short link (i.e.,`"abc123"` from `https://domain.com/abc123`)
+`Domain`       | The "domain" portion of the short link (i.e., `"domain.com"` from `https://domain.com/abc123`)
+`Id`           | The ID of the short code (in `code_123456789012345678901234` format)
+`LongUrl`      | The URL that the short code sends users to
+`Organization` | The organization that owns the short code
+`Tags`         | The tags associated with the short code
+`Title`        | The title of the short code
+
+The `GetShortCodeStats` API returns a collection of information about usage of your short codes. That includes information about the browsers using the short code, the devices using the short code, the countries where the short code usage took place in, referrers that sent users to the short code, and a daily click count summary for the requested time range.
+
+_Note that the `Get` APIs which may return 404s will return `null` values if the request was for an unknown short code ID or organization ID. The `Create` and `Update` APIs will throw exceptions if the short code ID or organization ID are unknown._
+
+#### QR Code APIs
+
+The `ILink` interface contains the following APIs related to QR codes:
+
+Method         | Description
+---------------|------------
+`CreateQrCode` | Creates a QR code
+`DeleteQrCode` | Deletes a QR code
+`GetQrCode`    | Gets information about a specific QR code
+`GetQrCodes`   | Gets a list of QR codes that match the optional search criteria
+
+Several APIs return one or more `QrCodeResult` instances, which include the following properties:
+
+Property | Description
+---------|------------
+`Id`     | The ID of the QR code (in `lqr_123456789012345678901234` format)
+`Link`   | The link for the short code that the QR code points to
+`QrCode` | The QR code (in `data:image/png;base64,BASE64_ENCODED_IMAGE` format)
+`Title`  | The title of the QR code
+
+The `QrCodeResult` also includes two helper methods to decode the `QrCode` property value:
+
+Method           | Description
+-----------------|------------
+`GetQrCodeBytes` | Get the QR code in `byte[]` format
+`SaveQrCode`     | Save the QR to a file on disk
+
+_Note that QR codes are always provided in PNG format, so when saving them to disk, you should use a `.png` file extension._
 
 ## net-info (Geo Information Service)
 

--- a/dotnet-sdk.slnx
+++ b/dotnet-sdk.slnx
@@ -16,6 +16,7 @@
   <Folder Name="/samples/">
     <File Path="samples/Directory.Build.props" />
     <Project Path="samples/EnvSample/EnvSample.csproj" />
+    <Project Path="samples/LinkSample/LinkSample.csproj" />
     <Project Path="samples/NetInfoSample/NetInfoSample.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/samples/LinkSample/LinkSample.csproj
+++ b/samples/LinkSample/LinkSample.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hyphen.Sdk\Hyphen.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/LinkSample/Program.cs
+++ b/samples/LinkSample/Program.cs
@@ -1,0 +1,27 @@
+using Hyphen.Sdk;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddLink();
+
+// Configure these if they aren't available via environment variable
+builder.Services.Configure<LinkOptions>(options =>
+{
+	//options.ApiKey = "";
+	//options.OrganizationId = "";
+});
+
+var host = builder.Build();
+
+var link = host.Services.GetRequiredService<ILink>();
+var tags = await link.GetTags();
+
+if (tags is null)
+	Console.WriteLine("Could not find tags. Is your organization ID correct?");
+else
+{
+	Console.WriteLine("Your short code tags:");
+
+	foreach (var tag in tags.OrderBy(x => x))
+		Console.WriteLine("* {0}", tag);
+}

--- a/samples/LinkSample/appsettings.json
+++ b/samples/LinkSample/appsettings.json
@@ -1,0 +1,9 @@
+{
+	"Logging": {
+		"Console": {
+			"LogLevel": {
+				"Default": "Warning"
+			}
+		}
+	}
+}

--- a/src/Hyphen.Sdk/Abstractions/ILink.cs
+++ b/src/Hyphen.Sdk/Abstractions/ILink.cs
@@ -1,0 +1,129 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// A Hyphen service which can manage short codes.
+/// </summary>
+public interface ILink
+{
+	/// <summary>
+	/// Creates a QR code which points at a short code link.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="parms">Optional parameters for creating the QR code.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>Returns the QR code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown short code ID or organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<QrCodeResult> CreateQrCode(string shortCodeId, CreateQrCodeParams? parms, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Creates a short code for a long URL.
+	/// </summary>
+	/// <param name="longUrl">The long URL to shorten.</param>
+	/// <param name="domain">The domain to use for the short code.</param>
+	/// <param name="parms">Optional parameters for creating the short code.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>Returns the short code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<ShortCodeResult> CreateShortCode(Uri longUrl, string domain, CreateShortCodeParams? parms, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Deletes a QR code.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="qrCodeId">The QR code ID. (Example: <c>"lqr_66fc51fe144cf3a1bd2a35b1"</c>)</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task DeleteQrCode(string shortCodeId, string qrCodeId, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Deletes a short code.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task DeleteShortCode(string shortCodeId, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets details about a short code.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="qrCodeId">The QR code ID. (Example: <c>"lqr_66fc51fe144cf3a1bd2a35b1"</c>)</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>Returns the QR code, if present; returns <c>null</c> for an unknown short code ID
+	/// or QR code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<QrCodeResult?> GetQrCode(string shortCodeId, string qrCodeId, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets a list of QR codes associated with a short code.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="parms">Optional parameters for getting the list of QR codes.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The list of QR codes that match the search options; returns <c>null</c> for an unknown
+	/// short code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<PagedResult<QrCodeResult>?> GetQrCodes(string shortCodeId, GetQrCodesParams? parms, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets a short code.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>Returns the short code, if available; returns <c>null</c> for an unknown code or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<ShortCodeResult?> GetShortCode(string shortCodeId, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets a list of short codes.
+	/// </summary>
+	/// <param name="parms">Optional parameters for getting the list of short codes.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The list of short codes that match the search options; returns <c>null</c> for an unknown organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<PagedResult<ShortCodeResult>?> GetShortCodes(GetShortCodesParams? parms, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets statistics for a given short code, for the provided date range.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="startDate">The start date.</param>
+	/// <param name="endDate">The end date.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The statistics for the given short code, if present; returns <c>null</c>
+	/// for an unknown short code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<ShortCodeStatsResult?> GetShortCodeStats(string shortCodeId, DateTimeOffset startDate, DateTimeOffset endDate, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets a list of all the tags used by the organization's short codes.
+	/// </summary>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The combined list of tags, if present; returns <c>null</c> for an unknown organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<string[]?> GetTags(CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Updates a short code.
+	/// </summary>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="parms">Parameters describing the changes to be made.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The updated short code</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown short code ID or organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	Task<ShortCodeResult> UpdateShortCode(string shortCodeId, UpdateShortCodeParams parms, CancellationToken cancellationToken);
+}

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkColorExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkColorExtensions.cs
@@ -1,0 +1,19 @@
+namespace System.Drawing;
+
+internal static class HyphenSdkColorExtensions
+{
+	public static string ToCss(this Color color)
+	{
+		var result = "#"
+			+ ToHexChar(color.R >> 4) + ToHexChar(color.R & 0xF)
+			+ ToHexChar(color.G >> 4) + ToHexChar(color.G & 0xF)
+			+ ToHexChar(color.B >> 4) + ToHexChar(color.B & 0xF);
+
+		if (color.A != 255)
+			result = result + ToHexChar(color.A >> 4) + ToHexChar(color.A & 0xF);
+
+		return result;
+	}
+
+	static char ToHexChar(int b) => (char)(b < 10 ? b + '0' : b - 10 + 'a');
+}

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkDateTimeOffsetExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkDateTimeOffsetExtensions.cs
@@ -1,0 +1,9 @@
+using System.Globalization;
+
+namespace System;
+
+internal static class HyphenSdkDateTimeOffsetExtensions
+{
+	public static string ToISO8601(this DateTimeOffset dateTime) =>
+		dateTime.ToString(@"yyyy-MM-ddTHH\:mm\:ss.fff\Z", CultureInfo.InvariantCulture);
+}

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkEnumExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkEnumExtensions.cs
@@ -1,0 +1,13 @@
+namespace Hyphen.Sdk;
+
+internal static class HyphenSdkEnumExtensions
+{
+	public static string ToFormString(this QrCodeSize size) =>
+		size switch
+		{
+			QrCodeSize.Small => "small",
+			QrCodeSize.Medium => "medium",
+			QrCodeSize.Large => "large",
+			_ => throw new ArgumentException("Unknown QrCodeSize value: " + size.ToString()),
+		};
+}

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkEnvExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkEnvExtensions.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Hyphen.Sdk.Internal;
 
 namespace Hyphen.Sdk;
 

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkHttpClientExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkHttpClientExtensions.cs
@@ -1,8 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Net.Http;
 
-[ExcludeFromCodeCoverage]
 internal static class HyphenSdkHttpClientExtensions
 {
 	public static void SetHyphenApiKey(this HttpClient client, string apiKey) =>

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkLinkExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkLinkExtensions.cs
@@ -1,0 +1,241 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Hyphen SDK extensions for <see cref="ILink"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class HyphenSdkLinkExtensions
+{
+	/// <summary>
+	/// Creates a QR code which points at a short code link.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <returns>Returns the QR code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown short code ID or organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<QrCodeResult> CreateQrCode(this ILink link, string shortCodeId) =>
+		Guard.ArgumentNotNull(link).CreateQrCode(shortCodeId, default, default);
+
+	/// <summary>
+	/// Creates a QR code which points at a short code link.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>Returns the QR code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown short code ID or organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<QrCodeResult> CreateQrCode(this ILink link, string shortCodeId, CancellationToken cancellationToken) =>
+		Guard.ArgumentNotNull(link).CreateQrCode(shortCodeId, default, cancellationToken);
+
+	/// <summary>
+	/// Creates a QR code which points at a short code link.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="parms">Optional parameters for creating the QR code.</param>
+	/// <returns>Returns the QR code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown short code ID or organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<QrCodeResult> CreateQrCode(this ILink link, string shortCodeId, CreateQrCodeParams? parms) =>
+		Guard.ArgumentNotNull(link).CreateQrCode(shortCodeId, parms, default);
+
+	/// <summary>
+	/// Creates a short code for a long URL.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="longUrl">The long URL to shorten.</param>
+	/// <param name="domain">The domain to use for the short code.</param>
+	/// <returns>Returns the short code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<ShortCodeResult> CreateShortCode(this ILink link, Uri longUrl, string domain) =>
+		Guard.ArgumentNotNull(link).CreateShortCode(longUrl, domain, default, default);
+
+	/// <summary>
+	/// Creates a short code for a long URL.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="longUrl">The long URL to shorten.</param>
+	/// <param name="domain">The domain to use for the short code.</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>Returns the short code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<ShortCodeResult> CreateShortCode(this ILink link, Uri longUrl, string domain, CancellationToken cancellationToken) =>
+		Guard.ArgumentNotNull(link).CreateShortCode(longUrl, domain, default, cancellationToken);
+
+	/// <summary>
+	/// Creates a short code for a long URL.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="longUrl">The long URL to shorten.</param>
+	/// <param name="domain">The domain to use for the short code.</param>
+	/// <param name="parms">Optional parameters for creating the short code.</param>
+	/// <returns>Returns the short code that was created.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<ShortCodeResult> CreateShortCode(this ILink link, Uri longUrl, string domain, CreateShortCodeParams? parms) =>
+		Guard.ArgumentNotNull(link).CreateShortCode(longUrl, domain, parms, default);
+
+	/// <summary>
+	/// Deletes a QR code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="qrCodeId">The QR code ID. (Example: <c>"lqr_66fc51fe144cf3a1bd2a35b1"</c>)</param>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task DeleteQrCode(this ILink link, string shortCodeId, string qrCodeId) =>
+		Guard.ArgumentNotNull(link).DeleteQrCode(shortCodeId, qrCodeId, default);
+
+	/// <summary>
+	/// Deletes a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task DeleteShortCode(this ILink link, string shortCodeId) =>
+		Guard.ArgumentNotNull(link).DeleteShortCode(shortCodeId, default);
+
+	/// <summary>
+	/// Gets details about a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="qrCodeId">The QR code ID. (Example: <c>"lqr_66fc51fe144cf3a1bd2a35b1"</c>)</param>
+	/// <returns>Returns the QR code, if present, returns <c>default</c> for an unknown short code ID
+	/// or QR code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<QrCodeResult?> GetQrCode(this ILink link, string shortCodeId, string qrCodeId) =>
+		Guard.ArgumentNotNull(link).GetQrCode(shortCodeId, qrCodeId, default);
+
+	/// <summary>
+	/// Gets a list of QR codes associated with a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <returns>The list of QR codes that match the search options; returns <c>null</c> for an unknown
+	/// short code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<PagedResult<QrCodeResult>?> GetQrCodes(this ILink link, string shortCodeId) =>
+		Guard.ArgumentNotNull(link).GetQrCodes(shortCodeId, default, default);
+
+	/// <summary>
+	/// Gets a list of QR codes associated with a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The list of QR codes that match the search options; returns <c>null</c> for an unknown
+	/// short code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<PagedResult<QrCodeResult>?> GetQrCodes(this ILink link, string shortCodeId, CancellationToken cancellationToken) =>
+		Guard.ArgumentNotNull(link).GetQrCodes(shortCodeId, default, cancellationToken);
+
+	/// <summary>
+	/// Gets a list of QR codes associated with a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="parms">Optional parameters for getting the list of QR codes.</param>
+	/// <returns>The list of QR codes that match the search options; returns <c>null</c> for an unknown
+	/// short code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<PagedResult<QrCodeResult>?> GetQrCodes(this ILink link, string shortCodeId, GetQrCodesParams? parms) =>
+		Guard.ArgumentNotNull(link).GetQrCodes(shortCodeId, parms, default);
+
+	/// <summary>
+	/// Gets a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <returns>Returns the short code, if available; returns <c>null</c> for an unknown code or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<ShortCodeResult?> GetShortCode(this ILink link, string shortCodeId) =>
+		Guard.ArgumentNotNull(link).GetShortCode(shortCodeId, default);
+
+	/// <summary>
+	/// Gets a list of short codes.
+	/// </summary>
+	/// <param name="link"/>
+	/// <returns>The list of short codes that match the search options; returns <c>null</c> for an unknown organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<PagedResult<ShortCodeResult>?> GetShortCodes(this ILink link) =>
+		Guard.ArgumentNotNull(link).GetShortCodes(default, default);
+
+	/// <summary>
+	/// Gets a list of short codes.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="cancellationToken">The cancellation token to cancel the request early</param>
+	/// <returns>The list of short codes that match the search options; returns <c>null</c> for an unknown organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<PagedResult<ShortCodeResult>?> GetShortCodes(this ILink link, CancellationToken cancellationToken) =>
+		Guard.ArgumentNotNull(link).GetShortCodes(default, cancellationToken);
+
+	/// <summary>
+	/// Gets a list of short codes.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="parms">Optional parameters for getting the list of short codes.</param>
+	/// <returns>The list of short codes that match the search options; returns <c>null</c> for an unknown organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<PagedResult<ShortCodeResult>?> GetShortCodes(this ILink link, GetShortCodesParams? parms) =>
+		Guard.ArgumentNotNull(link).GetShortCodes(parms, default);
+
+	/// <summary>
+	/// Gets statistics for a given short code, for the provided date range.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="startDate">The start date.</param>
+	/// <param name="endDate">The end date.</param>
+	/// <returns>The statistics for the given short code, if present; returns <c>null</c>
+	/// for an unknown short code ID or organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<ShortCodeStatsResult?> GetShortCodeStats(this ILink link, string shortCodeId, DateTimeOffset startDate, DateTimeOffset endDate) =>
+		Guard.ArgumentNotNull(link).GetShortCodeStats(shortCodeId, startDate, endDate, default);
+
+	/// <summary>
+	/// Gets a list of all the tags used by the organization's short codes.
+	/// </summary>
+	/// <param name="link"/>
+	/// <returns>The combined list of tags, if present; returns <c>null</c> for an unknown organization ID.</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<string[]?> GetTags(this ILink link) =>
+		Guard.ArgumentNotNull(link).GetTags(default);
+
+	/// <summary>
+	/// Updates a short code.
+	/// </summary>
+	/// <param name="link"/>
+	/// <param name="shortCodeId">The short code ID. (Example: <c>"code_686bed403c3991bd676bba4d"</c>)</param>
+	/// <param name="parms">Parameters describing the changes to be made.</param>
+	/// <returns>The updated short code</returns>
+	/// <exception cref="ApiKeyException">Thrown if the API key is not valid.</exception>
+	/// <exception cref="NotFoundException">Thrown for an unknown short code ID or organization ID.</exception>
+	/// <exception cref="HttpStatusCodeException">Thrown if the API returned an unexpected status code.</exception>
+	public static Task<ShortCodeResult> UpdateShortCode(this ILink link, string shortCodeId, UpdateShortCodeParams parms) =>
+		Guard.ArgumentNotNull(link).UpdateShortCode(shortCodeId, parms, default);
+}

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkNetInfoExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkNetInfoExtensions.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Hyphen.Sdk.Internal;
 
 namespace Hyphen.Sdk;
 

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkResourcesExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkResourcesExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 
@@ -8,7 +7,6 @@ using System.Text;
 
 namespace Hyphen.Sdk.Resources;
 
-[ExcludeFromCodeCoverage]
 internal static class HyphenSdkResourcesExtensions
 {
 #if !NETSTANDARD

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkResourcesExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkResourcesExtensions.cs
@@ -53,5 +53,17 @@ internal static class HyphenSdkResourcesExtensions
 				(int)statusCode,
 				statusCode
 			);
+
+		public static string Http_StatusCodeError(HttpStatusCode statusCode, string message) =>
+			string.Format(
+				CultureInfo.CurrentCulture,
+#if NETSTANDARD
+				HyphenSdkResources.Http_StatusCodeErrorFmt,
+#else
+				http_StatusCodeErrorComposite,
+#endif
+				(int)statusCode,
+				message
+			);
 	}
 }

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkServiceCollectionExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Hyphen.Sdk;
-using Hyphen.Sdk.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +19,20 @@ public static class HyphenSdkServiceCollectionExtensions
 		Guard.ArgumentNotNull(services)
 			.RegisterDependencies()
 			.TryAddSingleton<IEnv, Env>();
+
+		return services;
+	}
+
+	/// <summary>
+	/// Adds the <see cref="ILink"/> service to the <see cref="IServiceCollection"/>.
+	/// </summary>
+	/// <param name="services"/>
+	/// <returns>The <see cref="IServiceCollection"/>.</returns>
+	public static IServiceCollection AddLink(this IServiceCollection services)
+	{
+		Guard.ArgumentNotNull(services)
+			.RegisterDependencies()
+			.TryAddSingleton<ILink, Link>();
 
 		return services;
 	}

--- a/src/Hyphen.Sdk/Extensions/HyphenSdkStringExtensions.cs
+++ b/src/Hyphen.Sdk/Extensions/HyphenSdkStringExtensions.cs
@@ -1,8 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace System;
 
-[ExcludeFromCodeCoverage]
 internal static class HyphenSdkStringExtensions
 {
 #if NETSTANDARD

--- a/src/Hyphen.Sdk/Internal/CallerArgumentExpressionAttribute.cs
+++ b/src/Hyphen.Sdk/Internal/CallerArgumentExpressionAttribute.cs
@@ -2,14 +2,9 @@
 
 #if NETSTANDARD
 
-#pragma warning disable IDE0130 // Namespace does not match folder structure
-
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-[ExcludeFromCodeCoverage]
 internal sealed class CallerArgumentExpressionAttribute(string parameterName) : Attribute
 {
 	public string ParameterName { get; } = parameterName;

--- a/src/Hyphen.Sdk/Internal/Guard.cs
+++ b/src/Hyphen.Sdk/Internal/Guard.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-namespace Hyphen.Sdk.Internal;
+namespace Hyphen.Sdk;
 
 [ExcludeFromCodeCoverage]
 internal static class Guard
@@ -9,6 +9,12 @@ internal static class Guard
 	public static T ArgumentNotNull<T>([NotNull] T? argValue, [CallerArgumentExpression(nameof(argValue))] string? argName = null)
 		where T : class =>
 			argValue ?? throw new ArgumentNullException(argName?.TrimStart('@'));
+
+	public static void ArgumentValid(bool test, string failureMessage, string argName)
+	{
+		if (!test)
+			throw new ArgumentException(failureMessage, argName);
+	}
 
 	public static void True(bool test, string failureMessage)
 	{

--- a/src/Hyphen.Sdk/Internal/QueryStringBuilder.cs
+++ b/src/Hyphen.Sdk/Internal/QueryStringBuilder.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using System.Web;
+
+namespace Hyphen.Sdk;
+
+internal class QueryStringBuilder
+{
+	readonly StringBuilder result = new();
+
+	public void Add(string key, object? value)
+	{
+		if (value is null)
+			return;
+
+		if (result.Length == 0)
+			result.Append('?');
+		else
+			result.Append('&');
+
+		result.Append(HttpUtility.UrlEncode(key));
+		result.Append('=');
+		result.Append(HttpUtility.UrlEncode(value.ToString()));
+	}
+
+	public override string ToString() => result.ToString();
+}

--- a/src/Hyphen.Sdk/Internal/RequiredMemberAttribute.cs
+++ b/src/Hyphen.Sdk/Internal/RequiredMemberAttribute.cs
@@ -2,21 +2,15 @@
 
 // Compiler polyfill for .NET Framework
 
-#pragma warning disable IDE0130 // Namespace does not match folder structure
-
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Runtime.CompilerServices
 {
 	/// <summary/>
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
-	[ExcludeFromCodeCoverage]
 	internal sealed class RequiredMemberAttribute : Attribute
 	{ }
 
 	/// <summary/>
 	[AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
-	[ExcludeFromCodeCoverage]
 	internal sealed class CompilerFeatureRequiredAttribute(string featureName) :
 		Attribute
 	{
@@ -32,7 +26,6 @@ namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary/>
 	[AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
-	[ExcludeFromCodeCoverage]
 	internal sealed class SetsRequiredMembersAttribute : Attribute
 	{ }
 }

--- a/src/Hyphen.Sdk/Options/BaseHttpServiceOptions.cs
+++ b/src/Hyphen.Sdk/Options/BaseHttpServiceOptions.cs
@@ -1,12 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Hyphen.Sdk;
 
 /// <summary>
 /// Represents the options values that can be used to configure any service derived
 /// from <see cref="BaseHttpService"/>.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public class BaseHttpServiceOptions
 {
 	/// <summary>

--- a/src/Hyphen.Sdk/Options/EnvOptions.cs
+++ b/src/Hyphen.Sdk/Options/EnvOptions.cs
@@ -5,7 +5,6 @@ namespace Hyphen.Sdk;
 /// <summary>
 /// Represents the options values that can be used to configure <see cref="HyphenSdkServiceCollectionExtensions.AddHyphenEnv"/>.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public class EnvOptions
 {
 	/// <summary>
@@ -42,7 +41,11 @@ public class EnvOptions
 
 	internal Func<string, string?> GetEnv { get; set; } = System.Environment.GetEnvironmentVariable;
 
-	internal Func<string, string[]?> ReadFile { get; set; } = path => File.Exists(path) ? File.ReadAllLines(path) : null;
+	internal Func<string, string[]?> ReadFile { get; set; } = ReadFileInternal;
 
 	internal Action<string, string?> SetEnv { get; set; } = System.Environment.SetEnvironmentVariable;
+
+	[ExcludeFromCodeCoverage]  // We don't read files from disk in the unit tests
+	static string[]? ReadFileInternal(string path) =>
+		File.Exists(path) ? File.ReadAllLines(path) : null;
 }

--- a/src/Hyphen.Sdk/Options/LinkOptions.cs
+++ b/src/Hyphen.Sdk/Options/LinkOptions.cs
@@ -1,0 +1,29 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents the options values that can be used to configure <see cref="HyphenSdkServiceCollectionExtensions.AddLink"/>.
+/// </summary>
+public class LinkOptions : BaseHttpServiceOptions
+{
+	/// <summary>
+	/// Gets or sets the base URI template for the request.
+	/// </summary>
+	/// <remarks>
+	/// If the value is not set, the service will default to <c>"https://api.hyphen.ai/api/organizations/{organizationId}/link/codes/"</c>.<br />
+	/// <br/>
+	/// Any URI template will have the pattern <c>{organizationId}</c> replaced with the organization ID during the request.
+	/// </remarks>
+#pragma warning disable CA1056  // This is a template for a URI, not an actual URI
+	public string? BaseUriTemplate { get; set; }
+#pragma warning restore CA1056
+
+	/// <summary>
+	/// Gets or sets the organization ID.
+	/// </summary>
+	/// <remarks>
+	/// If the value is not set, the service class will assume that the user has set the environment
+	/// variable <c>HYPHEN_ORGANIZATION_ID</c> with the organization ID. If neither value is set, the
+	/// service class will throw an error about the missing organization ID.
+	/// </remarks>
+	public string? OrganizationId { get; set; }
+}

--- a/src/Hyphen.Sdk/Options/NetInfoOptions.cs
+++ b/src/Hyphen.Sdk/Options/NetInfoOptions.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Hyphen.Sdk;
 
 /// <summary>
 /// Represents the options values that can be used to configure <see cref="HyphenSdkServiceCollectionExtensions.AddNetInfo"/>.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public class NetInfoOptions : BaseHttpServiceOptions
 {
 	/// <summary>

--- a/src/Hyphen.Sdk/Package/README.md
+++ b/src/Hyphen.Sdk/Package/README.md
@@ -5,6 +5,7 @@
 The Hyphen .NET SDK is a .NET library that allows developers to easily integrate Hyphen features into their application, including:
 
 - [Secret Management Service](https://hyphen.ai/env) ("ENV")
+- [Short Code Service](https://hyphen.ai/link) ("Link")
 - [Geo Information Service](https://hyphen.ai/net-info) ("net-info")
 
 The library is compatible with .NET Standard 2.0 and .NET 8.

--- a/src/Hyphen.Sdk/Resources/HyphenSdkResources.Designer.cs
+++ b/src/Hyphen.Sdk/Resources/HyphenSdkResources.Designer.cs
@@ -115,6 +115,15 @@ namespace Hyphen.Sdk.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The provided API key is not valid for the request..
+        /// </summary>
+        internal static string Http_InvalidApiKey {
+            get {
+                return ResourceManager.GetString("Http_InvalidApiKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The HTTP response appears to be malformed and could not be deserialized..
         /// </summary>
         internal static string Http_ResponseMalformed {
@@ -124,11 +133,56 @@ namespace Hyphen.Sdk.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Received HTTP response code {0} ({1})..
+        ///   Looks up a localized string similar to Received HTTP response code {0}: {1}.
         /// </summary>
         internal static string Http_StatusCodeErrorFmt {
             get {
                 return ResourceManager.GetString("Http_StatusCodeErrorFmt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to While attempting to create a QR code: Unknown short code ID or organization ID..
+        /// </summary>
+        internal static string Link_CreateQrCode404 {
+            get {
+                return ResourceManager.GetString("Link_CreateQrCode404", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to While attempting to create a short code: Unknown organization ID..
+        /// </summary>
+        internal static string Link_CreateShortCode404 {
+            get {
+                return ResourceManager.GetString("Link_CreateShortCode404", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to While attempting to decode the QrCode value, it was in an unsupported format..
+        /// </summary>
+        internal static string Link_QrCodeInvalidFormat {
+            get {
+                return ResourceManager.GetString("Link_QrCodeInvalidFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to While attempting to update a short code: Unknown short code ID or organization ID..
+        /// </summary>
+        internal static string Link_UpdateShortCode404 {
+            get {
+                return ResourceManager.GetString("Link_UpdateShortCode404", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Organization ID is required. Please provide it via options or set the HYPHEN_ORGANIZATION_ID environment variable..
+        /// </summary>
+        internal static string OrganizationId_Required {
+            get {
+                return ResourceManager.GetString("OrganizationId_Required", resourceCulture);
             }
         }
     }

--- a/src/Hyphen.Sdk/Resources/HyphenSdkResources.resx
+++ b/src/Hyphen.Sdk/Resources/HyphenSdkResources.resx
@@ -121,7 +121,7 @@
     <value>API key is required. Please provide it via options or set the HYPHEN_API_KEY environment variable.</value>
   </data>
   <data name="Http_StatusCodeErrorFmt" xml:space="preserve">
-    <value>Received HTTP response code {0} ({1}).</value>
+    <value>Received HTTP response code {0}: {1}</value>
   </data>
   <data name="ApiKey_ShouldNotBePublic" xml:space="preserve">
     <value>The provided API key is a public API key. Please provide a valid non public API key for authentication.</value>
@@ -140,5 +140,23 @@
   </data>
   <data name="Env_InvalidLineFmt" xml:space="preserve">
     <value>While parsing "{0}", line "{1}" was not valid.</value>
+  </data>
+  <data name="OrganizationId_Required" xml:space="preserve">
+    <value>Organization ID is required. Please provide it via options or set the HYPHEN_ORGANIZATION_ID environment variable.</value>
+  </data>
+  <data name="Http_InvalidApiKey" xml:space="preserve">
+    <value>The provided API key is not valid for the request.</value>
+  </data>
+  <data name="Link_CreateQrCode404" xml:space="preserve">
+    <value>While attempting to create a QR code: Unknown short code ID or organization ID.</value>
+  </data>
+  <data name="Link_CreateShortCode404" xml:space="preserve">
+    <value>While attempting to create a short code: Unknown organization ID.</value>
+  </data>
+  <data name="Link_UpdateShortCode404" xml:space="preserve">
+    <value>While attempting to update a short code: Unknown short code ID or organization ID.</value>
+  </data>
+  <data name="Link_QrCodeInvalidFormat" xml:space="preserve">
+    <value>While attempting to decode the QrCode value, it was in an unsupported format.</value>
   </data>
 </root>

--- a/src/Hyphen.Sdk/Services/BaseHttpService.cs
+++ b/src/Hyphen.Sdk/Services/BaseHttpService.cs
@@ -1,5 +1,3 @@
-using Hyphen.Sdk.Internal;
-
 namespace Hyphen.Sdk;
 
 /// <summary>

--- a/src/Hyphen.Sdk/Services/BaseHttpService.cs
+++ b/src/Hyphen.Sdk/Services/BaseHttpService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Hyphen.Sdk.Internal;
 
 namespace Hyphen.Sdk;
@@ -15,12 +14,10 @@ public abstract class BaseHttpService(IHttpClientFactory httpClientFactory, ILog
 	/// <summary>
 	/// Gets the API key used to make service requests.
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	protected ApiKey ApiKey { get; } = Guard.ArgumentNotNull(options).Value.ApiKey;
 
 	/// <summary>
 	/// Gets the HTTP client factory used to make HTTP clients for service requests.
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	protected IHttpClientFactory HttpClientFactory { get; } = Guard.ArgumentNotNull(httpClientFactory);
 }

--- a/src/Hyphen.Sdk/Services/BaseService.cs
+++ b/src/Hyphen.Sdk/Services/BaseService.cs
@@ -1,5 +1,3 @@
-using Hyphen.Sdk.Internal;
-
 namespace Hyphen.Sdk;
 
 /// <summary>

--- a/src/Hyphen.Sdk/Services/Env.cs
+++ b/src/Hyphen.Sdk/Services/Env.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
-using Hyphen.Sdk.Internal;
 using Hyphen.Sdk.Resources;
 
 namespace Hyphen.Sdk;
@@ -14,6 +13,7 @@ internal partial class Env : BaseService, IEnv
 	public const string ApiKey = "HYPHEN_API_KEY";
 	public const string AppEnvironment = "HYPHEN_APP_ENVIRONMENT";
 	public const string Dev = "HYPHEN_DEV";
+	public const string OrganizationId = "HYPHEN_ORGANIZATION_ID";
 
 	const string NameRegexPattern =
 		/* lang=regex */ @"^([a-zA-Z_]+[a-zA-Z0-9_]*)\s*=\s*(.*?)$";

--- a/src/Hyphen.Sdk/Services/Env.cs
+++ b/src/Hyphen.Sdk/Services/Env.cs
@@ -76,7 +76,6 @@ internal partial class Env : BaseService, IEnv
 	/// <summary>
 	/// Gets a flag indicating whether environment variable <c>HYPHEN_DEV</c> is truthy.
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	internal static bool IsDevEnvironment => TrueValues.Contains(Environment.GetEnvironmentVariable(Dev));
 
 	public bool? GetBool(string name, [NotNullWhen(true)] bool required) =>

--- a/src/Hyphen.Sdk/Services/Link.cs
+++ b/src/Hyphen.Sdk/Services/Link.cs
@@ -86,7 +86,7 @@ internal class Link(IHttpClientFactory httpClientFactory, ILogger<ILink> logger,
 	{
 		Guard.ArgumentNotNull(shortCodeId);
 
-		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}");
+		var uri = new Uri(BaseUri, HttpUtility.UrlEncode(shortCodeId));
 		var client = HttpClientFactory.CreateClient(nameof(ILink));
 		client.SetHyphenApiKey(ApiKey);
 

--- a/src/Hyphen.Sdk/Services/Link.cs
+++ b/src/Hyphen.Sdk/Services/Link.cs
@@ -1,0 +1,245 @@
+using System.Drawing;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Web;
+using Hyphen.Sdk.Resources;
+
+namespace Hyphen.Sdk;
+
+internal class Link(IHttpClientFactory httpClientFactory, ILogger<ILink> logger, IOptions<LinkOptions> options)
+	: BaseHttpService(httpClientFactory, logger, options), ILink
+{
+	static readonly JsonSerializerOptions jsonSerializerOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
+	internal Uri BaseUri { get; } = GetBaseUri(Guard.ArgumentNotNull(options).Value.BaseUriTemplate, options.Value.OrganizationId);
+
+	public async Task<QrCodeResult> CreateQrCode(string shortCodeId, CreateQrCodeParams? parms, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+
+		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}/qrs");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		using var form = new MultipartFormDataContent("hyphen-dotnet-sdk");
+#pragma warning disable CA2000 // The child content objects are disposed by MultipartFormDataContent
+		if (parms?.BackgroundColor is not null)
+			form.Add(new StringContent(parms.BackgroundColor.Value.ToCss()), "backgroundColor");
+		if (parms?.Color is not null)
+			form.Add(new StringContent(parms.Color.Value.ToCss()), "color");
+		if (parms?.Logo is not null)
+		{
+			var logoContent = new ByteArrayContent(parms.Logo);
+			logoContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
+			form.Add(logoContent, "logo");
+		}
+		if (parms?.Size is not null)
+			form.Add(new StringContent(parms.Size.Value.ToFormString()), "size");
+		if (parms?.Title is not null)
+			form.Add(new StringContent(parms.Title), "title");
+#pragma warning restore CA2000
+
+		var response = await client.PostAsync(uri, form.Any() ? form : null, cancellationToken).ConfigureAwait(false);
+		return
+			await ProcessResponse<QrCodeResult>(response, cancellationToken).ConfigureAwait(false)
+				?? throw new NotFoundException(HyphenSdkResources.Link_CreateQrCode404);
+	}
+
+	public async Task<ShortCodeResult> CreateShortCode(Uri longUrl, string domain, CreateShortCodeParams? parms, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(longUrl);
+		Guard.ArgumentNotNull(domain);
+
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var postBody = new
+		{
+			long_url = longUrl,
+			domain,
+			code = parms?.Code,
+			title = parms?.Title,
+			tags = parms?.Tags,
+		};
+
+		var response = await client.PostAsJsonAsync(BaseUri, postBody, jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+		return
+			await ProcessResponse<ShortCodeResult>(response, cancellationToken).ConfigureAwait(false)
+				?? throw new NotFoundException(HyphenSdkResources.Link_CreateShortCode404);
+	}
+
+	public async Task DeleteQrCode(string shortCodeId, string qrCodeId, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+		Guard.ArgumentNotNull(qrCodeId);
+
+		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}/qrs/{HttpUtility.UrlEncode(qrCodeId)}");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.DeleteAsync(uri, cancellationToken).ConfigureAwait(false);
+		await ProcessResponse(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task DeleteShortCode(string shortCodeId, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+
+		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.DeleteAsync(uri, cancellationToken).ConfigureAwait(false);
+		await ProcessResponse(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<QrCodeResult?> GetQrCode(string shortCodeId, string qrCodeId, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+		Guard.ArgumentNotNull(qrCodeId);
+
+		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}/qrs/{HttpUtility.UrlEncode(qrCodeId)}");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+		return await ProcessResponse<QrCodeResult>(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<PagedResult<QrCodeResult>?> GetQrCodes(string shortCodeId, GetQrCodesParams? parms, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+
+		var query = new QueryStringBuilder();
+		query.Add("pageNum", parms?.PageNumber);
+		query.Add("pageSize", parms?.PageSize);
+
+		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}/qrs{query}");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+		return await ProcessResponse<PagedResult<QrCodeResult>>(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<ShortCodeResult?> GetShortCode(string shortCodeId, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+
+		var uri = new Uri(BaseUri, HttpUtility.UrlEncode(shortCodeId));
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+		return await ProcessResponse<ShortCodeResult>(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<PagedResult<ShortCodeResult>?> GetShortCodes(GetShortCodesParams? parms, CancellationToken cancellationToken)
+	{
+		var query = new QueryStringBuilder();
+		query.Add("pageNum", parms?.PageNumber);
+		query.Add("pageSize", parms?.PageSize);
+		query.Add("search", parms?.Search);
+		if (parms?.Tags?.Count > 0)
+			query.Add("tags", string.Join(",", parms.Tags));
+
+		var uri = new Uri(BaseUri, query.ToString());
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+		return await ProcessResponse<PagedResult<ShortCodeResult>>(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<ShortCodeStatsResult?> GetShortCodeStats(string shortCodeId, DateTimeOffset startDate, DateTimeOffset endDate, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+
+		var uri = new Uri(BaseUri, $"{HttpUtility.UrlEncode(shortCodeId)}/stats?startDate={startDate.ToISO8601()}&endDate={endDate.ToISO8601()}");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+		return await ProcessResponse<ShortCodeStatsResult>(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<string[]?> GetTags(CancellationToken cancellationToken)
+	{
+		var uri = new Uri(BaseUri, "tags");
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+		return await ProcessResponse<string[]>(response, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<ShortCodeResult> UpdateShortCode(string shortCodeId, UpdateShortCodeParams parms, CancellationToken cancellationToken)
+	{
+		Guard.ArgumentNotNull(shortCodeId);
+		Guard.ArgumentNotNull(parms);
+
+		var uri = new Uri(BaseUri, HttpUtility.UrlEncode(shortCodeId));
+		var client = HttpClientFactory.CreateClient(nameof(ILink));
+		client.SetHyphenApiKey(ApiKey);
+
+		var patchBody = new
+		{
+			long_url = parms.LongUrl,
+			title = parms.Title,
+			tags = parms.Tags,
+		};
+
+		var response = await client.PatchAsJsonAsync(uri, patchBody, jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+		return
+			await ProcessResponse<ShortCodeResult>(response, cancellationToken).ConfigureAwait(false)
+				?? throw new NotFoundException(HyphenSdkResources.Link_UpdateShortCode404);
+	}
+
+	// Helpers
+
+	static Uri GetBaseUri(string? baseUriTemplate, OrganizationId organizationId)
+	{
+		baseUriTemplate ??=
+			Env.IsDevEnvironment
+				? "https://dev-api.hyphen.ai/api/organizations/{organizationId}/link/codes"
+				: "https://api.hyphen.ai/api/organizations/{organizationId}/link/codes";
+
+		return new(baseUriTemplate.ReplaceInvariant("{organizationId}", organizationId).TrimEnd('/') + '/');
+	}
+
+	static async Task<bool> ProcessResponse(HttpResponseMessage response, CancellationToken cancellationToken)
+	{
+		if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+			throw new ApiKeyException(HyphenSdkResources.Http_InvalidApiKey);
+		if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.NoContent)
+			return false;
+		if (!response.IsSuccessStatusCode)
+			throw new HttpStatusCodeException(response.StatusCode);
+
+		return true;
+	}
+
+	static async Task<T?> ProcessResponse<T>(HttpResponseMessage response, CancellationToken cancellationToken)
+		where T : notnull
+	{
+		if (!await ProcessResponse(response, cancellationToken).ConfigureAwait(false))
+			return default;
+
+		try
+		{
+#if NETSTANDARD
+			using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+			using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+			return
+				await JsonSerializer.DeserializeAsync<T>(stream, cancellationToken: cancellationToken).ConfigureAwait(false)
+					?? throw new HttpStatusCodeException(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed);
+		}
+		catch (JsonException)
+		{
+			throw new HttpStatusCodeException(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed);
+		}
+	}
+}

--- a/src/Hyphen.Sdk/Services/NetInfo.cs
+++ b/src/Hyphen.Sdk/Services/NetInfo.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Json;
-using Hyphen.Sdk.Internal;
 using Hyphen.Sdk.Resources;
 
 namespace Hyphen.Sdk;

--- a/src/Hyphen.Sdk/Services/NetInfo.cs
+++ b/src/Hyphen.Sdk/Services/NetInfo.cs
@@ -7,9 +7,7 @@ namespace Hyphen.Sdk;
 internal class NetInfo(IHttpClientFactory httpClientFactory, ILogger<INetInfo> logger, IOptions<NetInfoOptions> options)
 	: BaseHttpService(httpClientFactory, logger, options), INetInfo
 {
-	internal Uri BaseUri { get; } =
-		Guard.ArgumentNotNull(options).Value.BaseUri
-			?? (Env.IsDevEnvironment ? new("https://dev.net.info") : new("https://net.info"));
+	internal Uri BaseUri { get; } = GetBaseUri(Guard.ArgumentNotNull(options).Value.BaseUri?.ToString());
 
 	public Task<NetInfoResult[]> GetIPInfos(string[] ips, CancellationToken cancellationToken)
 	{
@@ -33,6 +31,18 @@ internal class NetInfo(IHttpClientFactory httpClientFactory, ILogger<INetInfo> l
 				content => content.Data,
 				cancellationToken
 			);
+	}
+
+	// Helpers
+
+	static Uri GetBaseUri(string? baseUri)
+	{
+		baseUri ??=
+			Env.IsDevEnvironment
+				? "https://dev.net.info"
+				: "https://net.info";
+
+		return new(baseUri.TrimEnd('/') + '/');
 	}
 
 	async static Task<NetInfoResult[]> ProcessResponse<T>(

--- a/src/Hyphen.Sdk/Types/ApiKey.cs
+++ b/src/Hyphen.Sdk/Types/ApiKey.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Hyphen.Sdk.Internal;
 using Hyphen.Sdk.Resources;
 
 namespace Hyphen.Sdk;

--- a/src/Hyphen.Sdk/Types/ApiKey.cs
+++ b/src/Hyphen.Sdk/Types/ApiKey.cs
@@ -48,12 +48,10 @@ public class ApiKey
 	/// <summary>
 	/// Converts an <see cref="ApiKey"/> into a <see cref="string"/>.
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	public static implicit operator string(ApiKey apiKey) => Guard.ArgumentNotNull(apiKey).apiKey;
 
 	/// <summary>
 	/// Converts a <see cref="string"/> into an <see cref="ApiKey"/>.
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	public static implicit operator ApiKey(string? apiKey) => new(apiKey);
 }

--- a/src/Hyphen.Sdk/Types/Exceptions/ApiKeyException.cs
+++ b/src/Hyphen.Sdk/Types/Exceptions/ApiKeyException.cs
@@ -6,24 +6,8 @@ namespace Hyphen.Sdk;
 /// Represents a problem with the API key.
 /// </summary>
 /// <param name="message">The error message that explains the reason for the exception.</param>
-/// <param name="inner">The exception that is the cause of the current exception, or a <c>null</c>
-/// reference if no inner exception is specified.</param>
 [Serializable]
 [ExcludeFromCodeCoverage]
-public class ApiKeyException(string? message, Exception? inner)
-	: Exception(message, inner)
-{
-	/// <summary>
-	/// Initializes a new instance of the <see cref="ApiKeyException"/> class.
-	/// </summary>
-	public ApiKeyException() : this(null, null)
-	{ }
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="ApiKeyException"/> class with
-	/// a specified error message.
-	/// </summary>
-	/// <param name="message">The error message that explains the reason for the exception.</param>
-	public ApiKeyException(string? message) : this(message, null)
-	{ }
-}
+public class ApiKeyException(string message)
+	: Exception(message)
+{ }

--- a/src/Hyphen.Sdk/Types/Exceptions/ApiKeyException.cs
+++ b/src/Hyphen.Sdk/Types/Exceptions/ApiKeyException.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Hyphen.Sdk;
 
 /// <summary>
@@ -7,7 +5,6 @@ namespace Hyphen.Sdk;
 /// </summary>
 /// <param name="message">The error message that explains the reason for the exception.</param>
 [Serializable]
-[ExcludeFromCodeCoverage]
 public class ApiKeyException(string message)
 	: Exception(message)
 { }

--- a/src/Hyphen.Sdk/Types/Exceptions/HttpStatusCodeException.cs
+++ b/src/Hyphen.Sdk/Types/Exceptions/HttpStatusCodeException.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using Hyphen.Sdk.Resources;
+
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a problem with an HTTP request.
+/// </summary>
+/// <param name="statusCode">The HTTP status code</param>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+[Serializable]
+public class HttpStatusCodeException(HttpStatusCode statusCode, string message)
+	: Exception(HyphenSdkResources.Http_StatusCodeError(statusCode, message))
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="HttpStatusCodeException"/> class.
+	/// </summary>
+	/// <param name="statusCode">The HTTP status code</param>
+	public HttpStatusCodeException(HttpStatusCode statusCode) : this(statusCode, statusCode.ToString())
+	{ }
+
+	/// <summary>
+	/// Gets the HTTP status code.
+	/// </summary>
+	public HttpStatusCode StatusCode => statusCode;
+}

--- a/src/Hyphen.Sdk/Types/Exceptions/NotFoundException.cs
+++ b/src/Hyphen.Sdk/Types/Exceptions/NotFoundException.cs
@@ -1,0 +1,15 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents an item not found.
+/// </summary>
+/// <remarks>
+/// This exception will only be thrown for update operations like <c>POST</c>, <c>PUT</c>, or <c>PATCH</c>.<br />
+/// <c>GET</c> operations which result in a 404 will typically return <c>null</c> values.<br />
+/// <c>DELETE</c> operations which result in a 404 will typically be silently ignored.
+/// </remarks>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+[Serializable]
+public class NotFoundException(string message)
+	: Exception(message)
+{ }

--- a/src/Hyphen.Sdk/Types/Link/CreateQrCodeParams.cs
+++ b/src/Hyphen.Sdk/Types/Link/CreateQrCodeParams.cs
@@ -1,0 +1,56 @@
+using System.Drawing;
+
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents optional parameters when calling <see cref="ILink.CreateQrCode"/>.
+/// </summary>
+public class CreateQrCodeParams
+{
+	/// <summary>
+	/// Gets or sets the background color for the QR code.
+	/// </summary>
+	public Color? BackgroundColor { get; set; }
+
+	/// <summary>
+	/// Gets or sets the foreground color for the QR code.
+	/// </summary>
+	public Color? Color { get; set; }
+
+	/// <summary>
+	/// Gets or sets the logo for the QR code.
+	/// </summary>
+	/// <remarks>
+	/// The bytes here should be the contents of the image file, which can be read from disk
+	/// with <see cref="File.ReadAllBytes"/>.<br/>
+	/// <br/>
+	/// Supported formats include:
+	/// <list type="bullet">
+	/// <item><c>.avif</c></item>
+	/// <item><c>.bmp</c></item>
+	/// <item><c>.dds</c></item>
+	/// <item><c>.exr</c> (OpenEXR)</item>
+	/// <item><c>.ff</c> (Farbfeld)</item>
+	/// <item><c>.gif</c></item>
+	/// <item><c>.hdr</c></item>
+	/// <item><c>.ico</c></item>
+	/// <item><c>.jpeg</c></item>
+	/// <item><c>.png</c></item>
+	/// <item><c>.pnm</c></item>
+	/// <item><c>.quo</c></item>
+	/// <item><c>.tiff</c></item>
+	/// <item><c>.webp</c></item>
+	/// </list>
+	/// </remarks>
+	public byte[]? Logo { get; set; }
+
+	/// <summary>
+	/// Gets or sets the size of the generated QR code.
+	/// </summary>
+	public QrCodeSize? Size { get; set; }
+
+	/// <summary>
+	/// Gets or sets the title of the QR code.
+	/// </summary>
+	public string? Title { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/CreateShortCodeParams.cs
+++ b/src/Hyphen.Sdk/Types/Link/CreateShortCodeParams.cs
@@ -1,0 +1,25 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents optional parameters when calling <see cref="ILink.CreateShortCode"/>.
+/// </summary>
+public class CreateShortCodeParams
+{
+	/// <summary>
+	/// Gets or sets the short code used for the link.
+	/// </summary>
+	/// <remarks>
+	/// If this value is unset, a random code will be generated.
+	/// </remarks>
+	public string? Code { get; set; }
+
+	/// <summary>
+	/// Gets or sets the optional tags associated with the link.
+	/// </summary>
+	public IReadOnlyCollection<string>? Tags { get; set; }
+
+	/// <summary>
+	/// Gets or sets the optional title for the link.
+	/// </summary>
+	public string? Title { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/GetQrCodesParams.cs
+++ b/src/Hyphen.Sdk/Types/Link/GetQrCodesParams.cs
@@ -1,0 +1,7 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents optional parameters when calling <see cref="ILink.GetQrCodes"/>.
+/// </summary>
+public class GetQrCodesParams : PagedParams
+{ }

--- a/src/Hyphen.Sdk/Types/Link/GetShortCodesParams.cs
+++ b/src/Hyphen.Sdk/Types/Link/GetShortCodesParams.cs
@@ -1,0 +1,20 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents optional parameters when calling <see cref="ILink.GetShortCodes"/>.
+/// </summary>
+public class GetShortCodesParams : PagedParams
+{
+	/// <summary>
+	/// Gets or sets an optional search term filter.
+	/// </summary>
+	/// <remarks>
+	/// Searches are performed across codes, URLs, and titles.
+	/// </remarks>
+	public string? Search { get; set; }
+
+	/// <summary>
+	/// Gets or sets an optional tag list filter for short code tags.
+	/// </summary>
+	public IReadOnlyCollection<string>? Tags { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/LinkBrowser.cs
+++ b/src/Hyphen.Sdk/Types/Link/LinkBrowser.cs
@@ -1,0 +1,19 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a browser used by a short code link.
+/// </summary>
+public class LinkBrowser
+{
+	/// <summary>
+	/// The name of the browser.
+	/// </summary>
+	[JsonPropertyName("name")]
+	public required string Name { get; set; }
+
+	/// <summary>
+	/// The total number of times the browser was seen.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required long Total { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/LinkClicks.cs
+++ b/src/Hyphen.Sdk/Types/Link/LinkClicks.cs
@@ -1,0 +1,25 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a collection of <see cref="LinkClicksByDay"/> objects.
+/// </summary>
+public class LinkClicks
+{
+	/// <summary>
+	/// Gets or sets the list of clicks broken out by day.
+	/// </summary>
+	[JsonPropertyName("byDay")]
+	public required LinkClicksByDay[] ByDay { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of clicks across all reported days.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required long Total { get; set; }
+
+	/// <summary>
+	/// Gets or sets the number of unique users across all reported days.
+	/// </summary>
+	[JsonPropertyName("unique")]
+	public required long Unique { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/LinkClicksByDay.cs
+++ b/src/Hyphen.Sdk/Types/Link/LinkClicksByDay.cs
@@ -1,0 +1,25 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a count of clicks for a specific day.
+/// </summary>
+public class LinkClicksByDay
+{
+	/// <summary>
+	/// Gets or sets the date this click report represents.
+	/// </summary>
+	[JsonPropertyName("date")]
+	public required DateTimeOffset Date { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of clicks for the day.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required long Total { get; set; }
+
+	/// <summary>
+	/// Gets or sets the number of unique users for the day.
+	/// </summary>
+	[JsonPropertyName("unique")]
+	public required long Unique { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/LinkDevice.cs
+++ b/src/Hyphen.Sdk/Types/Link/LinkDevice.cs
@@ -1,0 +1,19 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a device type that used a short code link.
+/// </summary>
+public class LinkDevice
+{
+	/// <summary>
+	/// Gets or sets the name of the device type.
+	/// </summary>
+	[JsonPropertyName("name")]
+	public required string Name { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of times the device type used the short link code.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required int Total { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/LinkLocation.cs
+++ b/src/Hyphen.Sdk/Types/Link/LinkLocation.cs
@@ -1,0 +1,25 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a location that used a short code link.
+/// </summary>
+public class LinkLocation
+{
+	/// <summary>
+	/// Gets or sets the country name.
+	/// </summary>
+	[JsonPropertyName("country")]
+	public required string Country { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of times the given country used the short code link.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required int Total { get; set; }
+
+	/// <summary>
+	/// Gets or sets the number of unique users in the given country that used the short code link.
+	/// </summary>
+	[JsonPropertyName("unique")]
+	public required int Unique { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/LinkReferral.cs
+++ b/src/Hyphen.Sdk/Types/Link/LinkReferral.cs
@@ -1,0 +1,19 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents a referral for a short code link.
+/// </summary>
+public class LinkReferral
+{
+	/// <summary>
+	/// Gets or sets the total number of times a referral from <see cref="Url"/> occurred.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required long Total { get; set; }
+
+	/// <summary>
+	/// Gets or sets the URL of the referral.
+	/// </summary>
+	[JsonPropertyName("url")]
+	public required Uri Url { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/OrganizationIdResult.cs
+++ b/src/Hyphen.Sdk/Types/Link/OrganizationIdResult.cs
@@ -1,0 +1,19 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents an organization in an HTTP response.
+/// </summary>
+public class OrganizationResult
+{
+	/// <summary>
+	/// Gets or sets the organization ID.
+	/// </summary>
+	[JsonPropertyName("id")]
+	public required string Id { get; set; }
+
+	/// <summary>
+	/// Gets or sets the organization name.
+	/// </summary>
+	[JsonPropertyName("name")]
+	public required string Name { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/QrCodeResult.cs
+++ b/src/Hyphen.Sdk/Types/Link/QrCodeResult.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+using Hyphen.Sdk.Resources;
+
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents the result of getting, creating, or updating a QR code.
+/// </summary>
+public class QrCodeResult
+{
+	const string QrCodeHeader = "data:image/png;base64,";
+
+	/// <summary>
+	/// Gets or sets the ID of the QR code.
+	/// </summary>
+	[JsonPropertyName("id")]
+	public required string Id { get; set; }
+
+	/// <summary>
+	/// Gets or sets the URI that the QR code points to.
+	/// </summary>
+	[JsonPropertyName("qrLink")]
+	public required Uri Link { get; set; }
+
+	/// <summary>
+	/// Gets or sets the QR code.
+	/// </summary>
+	/// <remarks>
+	/// This value is a MIME representation of the QR code image. It will typically be in the format
+	/// of <c>"data:image/png;base64,BASE64_ENCODED_IMAGE"</c>. The <see cref="GetQrCodeBytes"/> method
+	/// can be used to retrieve the raw image data as bytes, and <see cref="SaveQrCode(string, CancellationToken)"/>
+	/// method can be used to save the raw data to a local file.
+	/// </remarks>
+	[JsonPropertyName("qrCode")]
+	public required string QrCode { get; set; }
+
+	/// <summary>
+	/// Gets or sets the optional title of the QR code.
+	/// </summary>
+	[JsonPropertyName("title")]
+	public string? Title { get; set; }
+
+	/// <summary>
+	/// Gets the QR code image, in byte array form.
+	/// </summary>
+	public byte[] GetQrCodeBytes()
+	{
+		if (!QrCode.StartsWith(QrCodeHeader, StringComparison.InvariantCulture))
+			throw new InvalidOperationException(HyphenSdkResources.Link_QrCodeInvalidFormat);
+
+#if NETSTANDARD
+		return Convert.FromBase64String(QrCode.Substring(QrCodeHeader.Length));
+#else
+		return Convert.FromBase64String(QrCode[QrCodeHeader.Length..]);
+#endif
+	}
+
+	/// <summary>
+	/// Saves the QR code image to disk.
+	/// </summary>
+	/// <param name="fileName">The file name to save the QR code image to.</param>
+	/// <remarks>
+	/// The QR code images are in PNG format, so it is recommended that the file name end with <c>".png"</c>.
+	/// </remarks>
+	[ExcludeFromCodeCoverage]
+	public Task SaveQrCode(string fileName) =>
+		SaveQrCode(fileName, default);
+
+	/// <summary>
+	/// Saves the QR code image to disk.
+	/// </summary>
+	/// <param name="fileName">The file name to save the QR code image to.</param>
+	/// <param name="cancellationToken">The cancellation token used to cancel the file write early.</param>
+	/// <remarks>
+	/// The QR code images are in PNG format, so it is recommended that the file name end with <c>".png"</c>.
+	/// </remarks>
+	[ExcludeFromCodeCoverage]  // Not testing due to file I/O (and simple implementation)
+	public Task SaveQrCode(string fileName, CancellationToken cancellationToken)
+	{
+#if NETSTANDARD
+		cancellationToken.ThrowIfCancellationRequested();
+		File.WriteAllBytes(fileName, GetQrCodeBytes());
+		return Task.CompletedTask;
+#else
+		return File.WriteAllBytesAsync(fileName, GetQrCodeBytes(), cancellationToken);
+#endif
+	}
+}

--- a/src/Hyphen.Sdk/Types/Link/QrCodeSize.cs
+++ b/src/Hyphen.Sdk/Types/Link/QrCodeSize.cs
@@ -1,0 +1,23 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents the size of a QR code.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<QrCodeSize>))]
+public enum QrCodeSize
+{
+	/// <summary>
+	/// Represents a small-sized QR code.
+	/// </summary>
+	Small,
+
+	/// <summary>
+	/// Represents a medium-sized QR code.
+	/// </summary>
+	Medium,
+
+	/// <summary>
+	/// Represents a large-sized QR code.
+	/// </summary>
+	Large,
+}

--- a/src/Hyphen.Sdk/Types/Link/ShortCodeResult.cs
+++ b/src/Hyphen.Sdk/Types/Link/ShortCodeResult.cs
@@ -1,0 +1,49 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents the result of getting, creating, or updating a short code link.
+/// </summary>
+public class ShortCodeResult
+{
+	/// <summary>
+	/// Gets or sets the short code.
+	/// </summary>
+	[JsonPropertyName("code")]
+	public required string Code { get; set; }
+
+	/// <summary>
+	/// Gets or sets the domain of the short code link.
+	/// </summary>
+	[JsonPropertyName("domain")]
+	public required string Domain { get; set; }
+
+	/// <summary>
+	/// Gets or sets the ID of the short code.
+	/// </summary>
+	[JsonPropertyName("id")]
+	public required string Id { get; set; }
+
+	/// <summary>
+	/// Gets or sets the URI that the short code points to.
+	/// </summary>
+	[JsonPropertyName("long_url")]
+	public required Uri LongUrl { get; set; }
+
+	/// <summary>
+	/// Gets or sets information about the organization that owns the short code.
+	/// </summary>
+	[JsonPropertyName("organization")]
+	public required OrganizationResult Organization { get; set; }
+
+	/// <summary>
+	/// Gets or sets the tags that are assocaited with the short code.
+	/// </summary>
+	[JsonPropertyName("tags")]
+	public required string[] Tags { get; set; }
+
+	/// <summary>
+	/// Gets or sets the title of the short code.
+	/// </summary>
+	[JsonPropertyName("title")]
+	public string? Title { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/ShortCodeStatsResult.cs
+++ b/src/Hyphen.Sdk/Types/Link/ShortCodeStatsResult.cs
@@ -1,0 +1,37 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents the result of getting statistics for a short code.
+/// </summary>
+public class ShortCodeStatsResult
+{
+	/// <summary>
+	/// Gets or sets the browsers that used a short code link.
+	/// </summary>
+	[JsonPropertyName("browsers")]
+	public required LinkBrowser[] Browsers { get; set; }
+
+	/// <summary>
+	/// Gets or sets the clicks that were recorded for the short code link.
+	/// </summary>
+	[JsonPropertyName("clicks")]
+	public required LinkClicks Clicks { get; set; }
+
+	/// <summary>
+	/// Gets or sets the devices that used a short code link.
+	/// </summary>
+	[JsonPropertyName("devices")]
+	public required LinkDevice[] Devices { get; set; }
+
+	/// <summary>
+	/// Gets or sets the locations that used a short code link.
+	/// </summary>
+	[JsonPropertyName("locations")]
+	public required LinkLocation[] Locations { get; set; }
+
+	/// <summary>
+	/// Gets or sets the referrals that came from a short code link.
+	/// </summary>
+	[JsonPropertyName("referrals")]
+	public required LinkReferral[] Referrals { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/Link/UpdateShortCodeParams.cs
+++ b/src/Hyphen.Sdk/Types/Link/UpdateShortCodeParams.cs
@@ -1,0 +1,32 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents optional parameters when calling <see cref="ILink.UpdateShortCode"/>.
+/// </summary>
+public class UpdateShortCodeParams
+{
+	/// <summary>
+	/// Gets or sets the URL that the short code link redirects to.
+	/// </summary>
+	/// <remarks>
+	/// If this value is unset, the URL will not be changed.
+	/// </remarks>
+	public Uri? LongUrl { get; set; }
+
+	/// <summary>
+	/// Gets or sets the optional tags associated with the link.
+	/// </summary>
+	/// <remarks>
+	/// If this value is unset, the tags will not be changed. To remove all the tags,
+	/// set this property to empty array.
+	/// </remarks>
+	public IReadOnlyCollection<string>? Tags { get; set; }
+
+	/// <summary>
+	/// Gets or sets the optional title for the link.
+	/// </summary>
+	/// <remarks>
+	/// If this value is unset, the title will not be changed.
+	/// </remarks>
+	public string? Title { get; set; }
+}

--- a/src/Hyphen.Sdk/Types/NetInfo/Location.cs
+++ b/src/Hyphen.Sdk/Types/NetInfo/Location.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Hyphen.Sdk;
 
 /// <summary>
 /// Represents a location returned from <see cref="INetInfo"/>.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public class Location
 {
 	/// <summary>

--- a/src/Hyphen.Sdk/Types/NetInfo/NetInfoPostResponse200.cs
+++ b/src/Hyphen.Sdk/Types/NetInfo/NetInfoPostResponse200.cs
@@ -1,8 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Hyphen.Sdk;
 
-[ExcludeFromCodeCoverage]
 internal class NetInfoPostResponse200
 {
 	[JsonPropertyName("data")]

--- a/src/Hyphen.Sdk/Types/NetInfo/NetInfoResult.cs
+++ b/src/Hyphen.Sdk/Types/NetInfo/NetInfoResult.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Hyphen.Sdk;
 
 /// <summary>
 /// Represents the return value from <see cref="INetInfo"/>.
 /// </summary>
-[ExcludeFromCodeCoverage]
 public class NetInfoResult
 {
 	/// <summary>

--- a/src/Hyphen.Sdk/Types/OrganizationId.cs
+++ b/src/Hyphen.Sdk/Types/OrganizationId.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+using Hyphen.Sdk.Resources;
+
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents an organization ID.
+/// </summary>
+public class OrganizationId
+{
+	readonly string organizationId;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="OrganizationId"/> class.
+	/// </summary>
+	/// <param name="organizationId">The optional organization ID. If not provided, then the environment
+	/// variable <c>HYPHEN_ORGANIZATION_ID</c> will be used as the organization ID.</param>
+	public OrganizationId(string? organizationId = null)
+	{
+		organizationId ??= Environment.GetEnvironmentVariable(Env.OrganizationId);
+
+		if (string.IsNullOrWhiteSpace(organizationId))
+			throw new ArgumentException(HyphenSdkResources.OrganizationId_Required);
+
+		this.organizationId = organizationId;
+	}
+
+	/// <summary>
+	/// Gets the API key value.
+	/// </summary>
+	[ExcludeFromCodeCoverage]
+	public string Value => organizationId;
+
+	/// <summary>
+	/// Create an instance of <see cref="OrganizationId"/> from a <see cref="string"/>.
+	/// </summary>
+	[ExcludeFromCodeCoverage]
+	public static OrganizationId FromString(string? organizationId) => new(organizationId);
+
+	/// <inheritdoc/>
+	[ExcludeFromCodeCoverage]
+	public override string ToString() => organizationId;
+
+	/// <summary>
+	/// Converts an <see cref="OrganizationId"/> into a <see cref="string"/>.
+	/// </summary>
+	public static implicit operator string(OrganizationId organizationId) => Guard.ArgumentNotNull(organizationId).organizationId;
+
+	/// <summary>
+	/// Converts a <see cref="string"/> into an <see cref="organizationId"/>.
+	/// </summary>
+	public static implicit operator OrganizationId(string? organizationId) => new(organizationId);
+}

--- a/src/Hyphen.Sdk/Types/PagedParams.cs
+++ b/src/Hyphen.Sdk/Types/PagedParams.cs
@@ -1,0 +1,39 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Base class for pagination options for multi-item requests.
+/// </summary>
+public class PagedParams
+{
+	/// <summary>
+	/// Gets or sets the page number for the request.
+	/// </summary>
+	/// <remarks>
+	/// Value value: a positive integer.
+	/// </remarks>
+	public int? PageNumber
+	{
+		get => field;
+		set
+		{
+			Guard.ArgumentValid(value is null || value >= 1, "Page number must be a positive integer", nameof(PageNumber));
+			field = value;
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the page size for the request.
+	/// </summary>
+	/// <remarks>
+	/// Valid value: a positive integer between <c>5</c> and <c>200</c>, inclusive.
+	/// </remarks>
+	public int? PageSize
+	{
+		get => field;
+		set
+		{
+			Guard.ArgumentValid(value is null || (value >= 5 && value <= 200), "Page size must be between 5 and 200", nameof(PageSize));
+			field = value;
+		}
+	}
+}

--- a/src/Hyphen.Sdk/Types/PagedResult.cs
+++ b/src/Hyphen.Sdk/Types/PagedResult.cs
@@ -1,0 +1,32 @@
+namespace Hyphen.Sdk;
+
+/// <summary>
+/// Represents results from a paged request.
+/// </summary>
+/// <typeparam name="T">The type of the results.</typeparam>
+public class PagedResult<T>
+{
+	/// <summary>
+	/// Gets or sets the retrieved data for this page.
+	/// </summary>
+	[JsonPropertyName("data")]
+	public required T[] Data { get; set; }
+
+	/// <summary>
+	/// Gets or sets the page number for the paged retrieval request.
+	/// </summary>
+	[JsonPropertyName("pageNum")]
+	public required int PageNumber { get; set; }
+
+	/// <summary>
+	/// Gets or sets the size of the results page.
+	/// </summary>
+	[JsonPropertyName("pageSize")]
+	public required int PageSize { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of data items available.
+	/// </summary>
+	[JsonPropertyName("total")]
+	public required int Total { get; set; }
+}

--- a/test/Hyphen.Sdk.Tests/Extensions/HyphenSdkColorExtensionsTests.cs
+++ b/test/Hyphen.Sdk.Tests/Extensions/HyphenSdkColorExtensionsTests.cs
@@ -1,0 +1,35 @@
+using System.Drawing;
+
+namespace Hyphen.Sdk;
+
+public class HyphenSdkColorExtensionsTests
+{
+	[Theory]
+	[InlineData(255, 0, 0, "#ff0000")]
+	[InlineData(0, 255, 0, "#00ff00")]
+	[InlineData(0, 0, 255, "#0000ff")]
+	public void ToCSS_RGB(byte red, byte green, byte blue, string expected)
+	{
+		var color = Color.FromArgb(red, green, blue);
+
+		var result = color.ToCss();
+
+		Assert.Equal(expected, result);
+	}
+
+	[Theory]
+	[InlineData(255, 0, 0, 255, "#ff0000")]
+	[InlineData(0, 255, 0, 255, "#00ff00")]
+	[InlineData(0, 0, 255, 255, "#0000ff")]
+	[InlineData(255, 0, 0, 127, "#ff00007f")]
+	[InlineData(0, 255, 0, 127, "#00ff007f")]
+	[InlineData(0, 0, 255, 127, "#0000ff7f")]
+	public void RGBA(byte red, byte green, byte blue, byte alpha, string expected)
+	{
+		var color = Color.FromArgb(alpha, red, green, blue);
+
+		var result = color.ToCss();
+
+		Assert.Equal(expected, result);
+	}
+}

--- a/test/Hyphen.Sdk.Tests/Extensions/HyphenSdkEnumExtensionsTests.cs
+++ b/test/Hyphen.Sdk.Tests/Extensions/HyphenSdkEnumExtensionsTests.cs
@@ -1,0 +1,24 @@
+namespace Hyphen.Sdk;
+
+public class HyphenSdkEnumExtensionsTests
+{
+	[Theory]
+	[InlineData(QrCodeSize.Large, "large")]
+	[InlineData(QrCodeSize.Medium, "medium")]
+	[InlineData(QrCodeSize.Small, "small")]
+	public void SuccessCases(QrCodeSize qrCodeSize, string expected)
+	{
+		var result = qrCodeSize.ToFormString();
+
+		Assert.Equal(expected, result);
+	}
+
+	[Fact]
+	public void GuardClause()
+	{
+		var ex = Record.Exception(() => ((QrCodeSize)99).ToFormString());
+
+		Assert.IsType<ArgumentException>(ex);
+		Assert.Equal("Unknown QrCodeSize value: 99", ex.Message);
+	}
+}

--- a/test/Hyphen.Sdk.Tests/Hyphen.Sdk.Tests.csproj
+++ b/test/Hyphen.Sdk.Tests/Hyphen.Sdk.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <LangVersion>14</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);CA2211</NoWarn>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Hyphen.Sdk.Tests</RootNamespace>

--- a/test/Hyphen.Sdk.Tests/Services/EnvTests.cs
+++ b/test/Hyphen.Sdk.Tests/Services/EnvTests.cs
@@ -38,10 +38,10 @@ public class EnvTests
 		}
 
 		[Fact]
-		public void UsesAppContextBaseDirectoryByDefault()
+		public void UsesAppContextBaseDirectoryByDefault_WithLocal()
 		{
 			var helper = new EnvHelper();
-			var options = new EnvOptions() { ReadFile = helper.ReadFile, SetEnv = helper.SetEnv };
+			var options = new EnvOptions() { ReadFile = helper.ReadFile, SetEnv = helper.SetEnv, Local = true };
 
 			var _ = new Env(logger, Options.Create(options));
 
@@ -50,6 +50,18 @@ public class EnvTests
 				path => Assert.Equal(Path.Combine(AppContext.BaseDirectory, ".env"), path),
 				path => Assert.Equal(Path.Combine(AppContext.BaseDirectory, ".env.local"), path)
 			);
+		}
+
+		[Fact]
+		public void UsesAppContextBaseDirectoryByDefault_WithoutLocal()
+		{
+			var helper = new EnvHelper();
+			var options = new EnvOptions() { ReadFile = helper.ReadFile, SetEnv = helper.SetEnv, Local = false };
+
+			var _ = new Env(logger, Options.Create(options));
+
+			var path = Assert.Single(helper.ReadFileRequests);
+			Assert.Equal(Path.Combine(AppContext.BaseDirectory, ".env"), path);
 		}
 
 		[Fact]

--- a/test/Hyphen.Sdk.Tests/Services/LinkTests.cs
+++ b/test/Hyphen.Sdk.Tests/Services/LinkTests.cs
@@ -1,0 +1,1249 @@
+#pragma warning disable xUnit1047  // Discovery enumeration has been disabled when appropriate
+
+using System.Drawing;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Hyphen.Sdk.Resources;
+
+namespace Hyphen.Sdk;
+
+[CleanEnvironment(Env.ApiKey, Env.Dev, Env.OrganizationId)]
+public class LinkTests
+{
+	const string OrganizationId = "org_123456789012345678901234";
+	const string QrCodeId = "lqr_123456789012345678901234";
+	const string ShortCodeId = "code_123456789012345678901234";
+	readonly DateTimeOffset StatsStartDate = DateTimeOffset.Now.AddDays(-5);
+	readonly DateTimeOffset StatsEndDate = DateTimeOffset.Now;
+	readonly string[] Tags = ["tag1", "tag2", "tag3"];
+
+	readonly IHttpClientFactory httpClientFactory;
+	readonly SpyLogger<ILink> logger;
+	readonly LinkOptions options = new() { ApiKey = "abc123", OrganizationId = OrganizationId };
+
+	public LinkTests()
+	{
+		httpClientFactory = Substitute.For<IHttpClientFactory>();
+		logger = new SpyLogger<ILink>();
+	}
+
+	public class Constructor : LinkTests
+	{
+		[Fact]
+		public void GuardClauses()
+		{
+			Assert.Throws<ArgumentNullException>("httpClientFactory", () => new Link(null!, logger, Options.Create(options)));
+			Assert.Throws<ArgumentNullException>("logger", () => new Link(httpClientFactory, null!, Options.Create(options)));
+			Assert.Throws<ArgumentNullException>("options", () => new Link(httpClientFactory, logger, null!));
+
+			options.ApiKey = null;
+
+			var ex1 = Assert.Throws<ApiKeyException>(() => new Link(httpClientFactory, logger, Options.Create(options)));
+			Assert.Equal("API key is required. Please provide it via options or set the HYPHEN_API_KEY environment variable.", ex1.Message);
+
+			options.ApiKey = "public_abc123";
+
+			var ex2 = Assert.Throws<ApiKeyException>(() => new Link(httpClientFactory, logger, Options.Create(options)));
+			Assert.Equal("The provided API key is a public API key. Please provide a valid non public API key for authentication.", ex2.Message);
+
+			options.ApiKey = "abc123";
+			options.OrganizationId = null;
+
+			var ex3 = Assert.Throws<ArgumentException>(() => new Link(httpClientFactory, logger, Options.Create(options)));
+			Assert.Equal("Organization ID is required. Please provide it via options or set the HYPHEN_ORGANIZATION_ID environment variable.", ex3.Message);
+		}
+
+		[Theory]
+		[InlineData("false", $"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/")]
+		[InlineData("true", $"https://dev-api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/")]
+		public void UsesDefaultBaseUri(string hyphenDevValue, string expectedUri)
+		{
+			Environment.SetEnvironmentVariable(Env.Dev, hyphenDevValue);
+
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			Assert.Equal(expectedUri, link.BaseUri.ToString());
+		}
+
+		[Theory]
+		[InlineData("http://localhost:12345/foo")]
+		[InlineData("http://localhost:12345/foo/")]
+		public void NormalizesTrailingSlashOnBaseUri(string baseUri)
+		{
+			options.BaseUriTemplate = baseUri;
+
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			Assert.Equal("http://localhost:12345/foo/", link.BaseUri.ToString());
+		}
+	}
+
+	public class CreateQrCode : LinkTests
+	{
+		public static IEnumerable<TheoryDataRow<CreateQrCodeParams?, string?>> ParamsData =
+		[
+			new(null, null),
+			new(
+				new()
+				{
+					BackgroundColor = Color.AliceBlue,
+					Color = Color.DarkKhaki,
+					Logo = Encoding.UTF8.GetBytes("Hello world"),
+					Size = QrCodeSize.Small,
+					Title = "QR Code Title",
+				},
+				"""
+				--hyphen-dotnet-sdk
+				Content-Type: text/plain; charset=utf-8
+				Content-Disposition: form-data; name=backgroundColor
+
+				#f0f8ff
+				--hyphen-dotnet-sdk
+				Content-Type: text/plain; charset=utf-8
+				Content-Disposition: form-data; name=color
+
+				#bdb76b
+				--hyphen-dotnet-sdk
+				Content-Type: application/octet-stream
+				Content-Disposition: form-data; name=logo
+
+				Hello world
+				--hyphen-dotnet-sdk
+				Content-Type: text/plain; charset=utf-8
+				Content-Disposition: form-data; name=size
+
+				small
+				--hyphen-dotnet-sdk
+				Content-Type: text/plain; charset=utf-8
+				Content-Disposition: form-data; name=title
+
+				QR Code Title
+				--hyphen-dotnet-sdk--
+
+				"""
+			),
+		];
+
+		[Theory]
+		[MemberData(nameof(ParamsData), DisableDiscoveryEnumeration = true)]
+		public async ValueTask Returns201(CreateQrCodeParams? parms, string? expectedPostBody)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var qrCode = new
+			{
+				id = QrCodeId,
+				qrCode = "base64_encoded_image",
+				qrLink = "http://localhost:12345/",
+				title = "QR Code Title",
+			};
+			var messageHandler = ReturnContent(qrCode, HttpStatusCode.Created);
+
+			var response = await link.CreateQrCode(ShortCodeId, parms, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Post, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Equal(expectedPostBody, request.Body, ignoreLineEndingDifferences: true);
+			Assert.Equivalent(new QrCodeResult
+			{
+				Id = QrCodeId,
+				Link = new Uri("http://localhost:12345/"),
+				QrCode = "base64_encoded_image",
+				Title = "QR Code Title",
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns201_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.CreateQrCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object), HttpStatusCode.Created));
+			await assertFailure(() => ReturnContent(new { }, HttpStatusCode.Created));
+			await assertFailure(() => ReturnContent(Array.Empty<object>(), HttpStatusCode.Created));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.CreateQrCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var ex = await Record.ExceptionAsync(() => link.CreateQrCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<NotFoundException>(ex);
+			Assert.Equal(HyphenSdkResources.Link_CreateQrCode404, ex.Message);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.CreateQrCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class CreateShortCode : LinkTests
+	{
+		public static IEnumerable<TheoryDataRow<CreateShortCodeParams?, string>> ParamsData =
+		[
+			new(
+				null,
+				"""{"long_url":"http://localhost:12345","domain":"foo.com"}"""
+			),
+			new(
+				new() { Code = "code", Title = "title", Tags = ["tag1", "tag2"] },
+				"""{"long_url":"http://localhost:12345","domain":"foo.com","code":"code","title":"title","tags":["tag1","tag2"]}"""
+			),
+		];
+
+		[Theory]
+		[MemberData(nameof(ParamsData))]
+		public async ValueTask Returns201(CreateShortCodeParams? parms, string expectedBody)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var shortCode = new
+			{
+				code = "code123",
+				domain = "foo.com",
+				id = ShortCodeId,
+				long_url = "http://localhost:12345/",
+				organization = new { id = OrganizationId, name = "Organization Name" },
+				tags = Tags,
+				title = "Code Title",
+			};
+			var messageHandler = ReturnContent(shortCode, HttpStatusCode.Created);
+
+			var response = await link.CreateShortCode(new("http://localhost:12345"), "foo.com", parms, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Post, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Equal(expectedBody, request.Body, ignoreLineEndingDifferences: true);
+			Assert.Equivalent(new ShortCodeResult
+			{
+				Code = "code123",
+				Domain = "foo.com",
+				Id = ShortCodeId,
+				LongUrl = new Uri("http://localhost:12345/"),
+				Organization = new OrganizationResult { Id = OrganizationId, Name = "Organization Name" },
+				Tags = Tags,
+				Title = "Code Title",
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns201_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.CreateShortCode(new("http://localhost:12345"), "foo.com", TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object), HttpStatusCode.Created));
+			await assertFailure(() => ReturnContent(new { }, HttpStatusCode.Created));
+			await assertFailure(() => ReturnContent(Array.Empty<object>(), HttpStatusCode.Created));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.CreateShortCode(new("http://localhost:12345"), "foo.com", TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var ex = await Record.ExceptionAsync(() => link.CreateShortCode(new("http://localhost:12345"), "foo.com", TestContext.Current.CancellationToken));
+
+			Assert.IsType<NotFoundException>(ex);
+			Assert.Equal(HyphenSdkResources.Link_CreateShortCode404, ex.Message);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.CreateShortCode(new("http://localhost:12345"), "foo.com", TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class DeleteQrCode : LinkTests
+	{
+		[Theory]
+		[InlineData(HttpStatusCode.NoContent)]
+		[InlineData(HttpStatusCode.NotFound)]
+		public async ValueTask Returns204_404(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var messageHandler = ReturnStatusCode(statusCode);
+
+			await link.DeleteQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Delete, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs/{QrCodeId}", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.DeleteQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.DeleteQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class DeleteShortCode : LinkTests
+	{
+		[Theory]
+		[InlineData(HttpStatusCode.NoContent)]
+		[InlineData(HttpStatusCode.NotFound)]
+		public async ValueTask Returns204_404(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var messageHandler = ReturnStatusCode(statusCode);
+
+			await link.DeleteShortCode(ShortCodeId, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Delete, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.DeleteShortCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.DeleteShortCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class GetQrCode : LinkTests
+	{
+		[Fact]
+		public async ValueTask Returns200()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var qrCode = new
+			{
+				id = QrCodeId,
+				qrCode = "base64_encoded_image",
+				qrLink = "http://localhost:12345/",
+				title = "QR Code Title",
+			};
+			var messageHandler = ReturnContent(qrCode);
+
+			var response = await link.GetQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Get, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs/{QrCodeId}", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+			Assert.Equivalent(new QrCodeResult
+			{
+				Id = QrCodeId,
+				Link = new Uri("http://localhost:12345/"),
+				QrCode = "base64_encoded_image",
+				Title = "QR Code Title",
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.GetQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(Array.Empty<object>()));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var response = await link.GetQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken);
+
+			Assert.Null(response);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetQrCode(ShortCodeId, QrCodeId, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class GetQrCodes : LinkTests
+	{
+		public static IEnumerable<TheoryDataRow<GetQrCodesParams?, string>> ParamsData =>
+		[
+			new(
+				null,
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs"
+			),
+			new(
+				new() { PageNumber = 24 },
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs?pageNum=24"
+			),
+			new(
+				new() { PageSize = 42 },
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs?pageSize=42"
+			),
+			new(
+				new() { PageNumber = 24, PageSize = 42 },
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/qrs?pageNum=24&pageSize=42"
+			),
+		];
+
+		[Theory]
+		[MemberData(nameof(ParamsData), DisableDiscoveryEnumeration = true)]
+		public async ValueTask Returns200(GetQrCodesParams? parms, string expectedUri)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var qrCodes = new
+			{
+				data = new[]
+				{
+					new
+					{
+						id = "lqr_000000000000000000000001",
+						qrCode = "base64_encoded_image_1",
+						qrLink = "http://localhost:12345/",
+						title = "QR Code 1",
+					},
+					new
+					{
+						id = "lqr_000000000000000000000002",
+						qrCode = "base64_encoded_image_2",
+						qrLink = "http://localhost:54321/",
+						title = "QR Code 2",
+					},
+				},
+				pageNum = 1,
+				pageSize = 50,
+				total = 2,
+			};
+			var messageHandler = ReturnContent(qrCodes);
+
+			var response = await link.GetQrCodes(ShortCodeId, parms, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Get, request.Method);
+			Assert.Equal(expectedUri, request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+			Assert.Equivalent(new PagedResult<QrCodeResult>
+			{
+				Data =
+				[
+					new QrCodeResult
+					{
+						Id = "lqr_000000000000000000000001",
+						Link = new Uri("http://localhost:12345/"),
+						QrCode = "base64_encoded_image_1",
+						Title = "QR Code 1",
+					},
+					new QrCodeResult
+					{
+						Id = "lqr_000000000000000000000002",
+						Link = new Uri("http://localhost:54321/"),
+						QrCode = "base64_encoded_image_2",
+						Title = "QR Code 2",
+					},
+				],
+				PageNumber = 1,
+				PageSize = 50,
+				Total = 2,
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.GetQrCodes(ShortCodeId, TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(Array.Empty<object>()));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetQrCodes(ShortCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var response = await link.GetQrCodes(ShortCodeId, TestContext.Current.CancellationToken);
+
+			Assert.Null(response);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetQrCodes(ShortCodeId, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class GetShortCode : LinkTests
+	{
+		[Fact]
+		public async ValueTask Returns200()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var shortCode = new
+			{
+				code = "code123",
+				domain = "foo.com",
+				id = ShortCodeId,
+				long_url = "http://localhost:12345/",
+				organization = new { id = OrganizationId, name = "Organization Name" },
+				tags = Tags,
+				title = "Code Title",
+			};
+			var messageHandler = ReturnContent(shortCode);
+
+			var response = await link.GetShortCode(ShortCodeId, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Get, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+			Assert.Equivalent(new ShortCodeResult
+			{
+				Code = "code123",
+				Domain = "foo.com",
+				Id = ShortCodeId,
+				LongUrl = new Uri("http://localhost:12345/"),
+				Organization = new OrganizationResult { Id = OrganizationId, Name = "Organization Name" },
+				Tags = Tags,
+				Title = "Code Title",
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.GetShortCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(Array.Empty<object>()));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetShortCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var response = await link.GetShortCode(ShortCodeId, TestContext.Current.CancellationToken);
+
+			Assert.Null(response);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetShortCode(ShortCodeId, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class GetShortCodes : LinkTests
+	{
+		public static IEnumerable<TheoryDataRow<GetShortCodesParams?, string>> ParamsData =>
+		[
+			new(
+				null,
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/"
+			),
+			new(
+				new() { PageNumber = 24, PageSize = 42 },
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/?pageNum=24&pageSize=42"
+			),
+			new(
+				new() { PageNumber = 24, PageSize = 42, Search = "Foo", Tags = ["bar", "baz"] },
+				$"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/?pageNum=24&pageSize=42&search=Foo&tags=bar%2cbaz"
+			),
+		];
+
+		[Theory]
+		[MemberData(nameof(ParamsData), DisableDiscoveryEnumeration = true)]
+		public async ValueTask Returns200(GetShortCodesParams? parms, string expectedUri)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var shortCodes = new
+			{
+				data = new[]
+				{
+					new {
+						code = "code1",
+						domain = "foo.com",
+						id = "code_000000000000000000000001",
+						long_url = "http://localhost:12345/",
+						organization = new { id = OrganizationId, name = "Organization Name" },
+						tags = Tags,
+						title = "Code Title 1",
+					},
+					new {
+						code = "code2",
+						domain = "bar.com",
+						id = "code_000000000000000000000002",
+						long_url = "http://localhost:54321/",
+						organization = new { id = OrganizationId, name = "Organization Name" },
+						tags = Array.Empty<string>(),
+						title = "Code Title 2",
+					},
+				},
+				pageNum = 1,
+				pageSize = 50,
+				total = 2,
+			};
+			var messageHandler = ReturnContent(shortCodes);
+
+			var response = await link.GetShortCodes(parms, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Get, request.Method);
+			Assert.Equal(expectedUri, request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+			Assert.Equivalent(new PagedResult<ShortCodeResult>
+			{
+				Data =
+				[
+					new ShortCodeResult
+					{
+						Code = "code1",
+						Domain = "foo.com",
+						Id = "code_000000000000000000000001",
+						LongUrl = new Uri("http://localhost:12345/"),
+						Organization = new OrganizationResult { Id = OrganizationId, Name = "Organization Name" },
+						Tags = Tags,
+						Title = "Code Title 1",
+					},
+					new ShortCodeResult
+					{
+						Code = "code2",
+						Domain = "bar.com",
+						Id = "code_000000000000000000000002",
+						LongUrl = new Uri("http://localhost:54321/"),
+						Organization = new OrganizationResult { Id = OrganizationId, Name = "Organization Name" },
+						Tags = [],
+						Title = "Code Title 2",
+					},
+				],
+				PageNumber = 1,
+				PageSize = 50,
+				Total = 2,
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.GetShortCodes(TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(Array.Empty<object>()));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetShortCodes(TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var response = await link.GetShortCodes(TestContext.Current.CancellationToken);
+
+			Assert.Null(response);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetShortCodes(TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class GetShortCodeStats : LinkTests
+	{
+		[Fact]
+		public async ValueTask Returns200()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var stats = new
+			{
+				browsers = new[] { new { name = "Chrome", total = 5 }, new { name = "Vivaldi", total = 12 } },
+				clicks = new
+				{
+					byDay = new[]
+					{
+						new { date = "2025-12-18T00:00:00.000Z", total = 2100, unique = 40 },
+						new { date = "2025-12-19T00:00:00.000Z", total = 12, unique = 2 },
+					},
+					total = 2112,
+					unique = 42,
+				},
+				devices = new[] { new { name = "Desktop", total = 18 }, new { name = "Phone", total = 6 } },
+				locations = new[] { new { country = "US", total = 24, unique = 12 }, new { country = "Canada", total = 16, unique = 8 } },
+				referrals = new[] { new { url = "http://localhost:12345/", total = 50 }, new { url = "http://localhost:54321/", total = 75 } },
+			};
+			var messageHandler = ReturnContent(stats);
+
+			var response = await link.GetShortCodeStats(ShortCodeId, StatsStartDate, StatsEndDate, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Get, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}/stats?startDate={StatsStartDate.ToISO8601()}&endDate={StatsEndDate.ToISO8601()}", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+			Assert.Equivalent(new ShortCodeStatsResult
+			{
+				Browsers = [new() { Name = "Chrome", Total = 5 }, new() { Name = "Vivaldi", Total = 12 }],
+				Clicks = new()
+				{
+					Total = 2112,
+					Unique = 42,
+					ByDay =
+					[
+						new LinkClicksByDay { Date = DateTimeOffset.Parse("2025-12-18T00:00:00.000Z"), Total = 2100, Unique = 40 },
+						new LinkClicksByDay { Date = DateTimeOffset.Parse("2025-12-19T00:00:00.0000000+00:00"), Total = 12, Unique = 2 },
+					]
+				},
+				Devices = [new() { Name = "Desktop", Total = 18 }, new() { Name = "Phone", Total = 6 }],
+				Locations = [new() { Country = "US", Total = 24, Unique = 12 }, new() { Country = "Canada", Total = 16, Unique = 8 }],
+				Referrals = [new() { Total = 50, Url = new("http://localhost:12345/") }, new() { Total = 75, Url = new("http://localhost:54321/") }],
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.GetShortCodeStats(ShortCodeId, StatsStartDate, StatsEndDate, TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(Array.Empty<object>()));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetShortCodeStats(ShortCodeId, StatsStartDate, StatsEndDate, TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var response = await link.GetShortCodeStats(ShortCodeId, StatsStartDate, StatsEndDate, TestContext.Current.CancellationToken);
+
+			Assert.Null(response);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetShortCodeStats(ShortCodeId, StatsStartDate, StatsEndDate, TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class GetTags : LinkTests
+	{
+		[Fact]
+		public async ValueTask Returns200()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var messageHandler = ReturnContent(Tags);
+
+			var response = await link.GetTags(TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Get, request.Method);
+			Assert.Equal("https://api.hyphen.ai/api/organizations/org_123456789012345678901234/link/codes/tags", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Null(request.Body);
+			Assert.Equal(Tags, response);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.GetTags(TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(new[] { 42, 2112 }));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetTags(TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var response = await link.GetTags(TestContext.Current.CancellationToken);
+
+			Assert.Null(response);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.GetTags(TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	public class UpdateShortCode : LinkTests
+	{
+		public static IEnumerable<TheoryDataRow<UpdateShortCodeParams, string>> ParamsData =
+		[
+			new(new(), "{}"),
+			new(
+				new() { LongUrl = new("http://localhost:12345"), Title = "title", Tags = ["tag1", "tag2"] },
+				"""{"long_url":"http://localhost:12345","title":"title","tags":["tag1","tag2"]}"""
+			),
+		];
+
+		[Theory]
+		[MemberData(nameof(ParamsData))]
+		public async ValueTask Returns200(UpdateShortCodeParams parms, string expectedBody)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			var shortCode = new
+			{
+				code = "code123",
+				domain = "foo.com",
+				id = ShortCodeId,
+				long_url = "http://localhost:12345/",
+				organization = new { id = OrganizationId, name = "Organization Name" },
+				tags = Tags,
+				title = "Code Title",
+			};
+			var messageHandler = ReturnContent(shortCode);
+
+			var response = await link.UpdateShortCode(ShortCodeId, parms, TestContext.Current.CancellationToken);
+
+			var request = Assert.Single(messageHandler.Requests);
+			Assert.Equal(HttpMethod.Patch, request.Method);
+			Assert.Equal($"https://api.hyphen.ai/api/organizations/{OrganizationId}/link/codes/{ShortCodeId}", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
+			Assert.Equal(expectedBody, request.Body, ignoreLineEndingDifferences: true);
+			Assert.Equivalent(new ShortCodeResult
+			{
+				Code = "code123",
+				Domain = "foo.com",
+				Id = ShortCodeId,
+				LongUrl = new Uri("http://localhost:12345/"),
+				Organization = new OrganizationResult { Id = OrganizationId, Name = "Organization Name" },
+				Tags = Tags,
+				Title = "Code Title",
+			}, response, strict: true);
+		}
+
+		[Fact]
+		public async ValueTask Returns200_MalformedResponses()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+
+			async ValueTask assertFailure(Action setup)
+			{
+				setup();
+
+				var ex = await Record.ExceptionAsync(() => link.UpdateShortCode(ShortCodeId, new(), TestContext.Current.CancellationToken));
+
+				// Malformed 200 is presented as a 503, on the assumption the service is broken
+				var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+				Assert.Equal(HttpStatusCode.ServiceUnavailable, hscEx.StatusCode);
+				Assert.Equal(HyphenSdkResources.Http_StatusCodeError(HttpStatusCode.ServiceUnavailable, HyphenSdkResources.Http_ResponseMalformed), hscEx.Message);
+			}
+
+			await assertFailure(() => ReturnContent(default(object)));
+			await assertFailure(() => ReturnContent(new { }));
+			await assertFailure(() => ReturnContent(Array.Empty<object>()));
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Unauthorized)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		public async ValueTask Returns401_403(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.UpdateShortCode(ShortCodeId, new(), TestContext.Current.CancellationToken));
+
+			Assert.IsType<ApiKeyException>(ex);
+			Assert.Equal(HyphenSdkResources.Http_InvalidApiKey, ex.Message);
+		}
+
+		[Fact]
+		public async ValueTask Returns404()
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(HttpStatusCode.NotFound);
+
+			var ex = await Record.ExceptionAsync(() => link.UpdateShortCode(ShortCodeId, new(), TestContext.Current.CancellationToken));
+
+			Assert.IsType<NotFoundException>(ex);
+			Assert.Equal(HyphenSdkResources.Link_UpdateShortCode404, ex.Message);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.InternalServerError)]
+		[InlineData(HttpStatusCode.NotImplemented)]
+		public async ValueTask ReturnsNon200(HttpStatusCode statusCode)
+		{
+			var link = new Link(httpClientFactory, logger, Options.Create(options));
+			ReturnStatusCode(statusCode);
+
+			var ex = await Record.ExceptionAsync(() => link.UpdateShortCode(ShortCodeId, new(), TestContext.Current.CancellationToken));
+
+			var hscEx = Assert.IsType<HttpStatusCodeException>(ex);
+			Assert.Equal(statusCode, hscEx.StatusCode);
+			Assert.Equal(HyphenSdkResources.Http_StatusCodeError(statusCode), hscEx.Message);
+		}
+	}
+
+	SpyHttpMessageHandler ReturnContent<T>(T content, HttpStatusCode statusCode = HttpStatusCode.OK)
+	{
+		var handler = new SpyHttpMessageHandler(_ => new HttpResponseMessage(statusCode) { Content = JsonContent.Create(content) });
+
+		httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+		return handler;
+	}
+
+	SpyHttpMessageHandler ReturnStatusCode(HttpStatusCode statusCode)
+	{
+		var handler = new SpyHttpMessageHandler(_ => new HttpResponseMessage(statusCode));
+
+		httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+		return handler;
+	}
+}

--- a/test/Hyphen.Sdk.Tests/Services/NetInfoTests.cs
+++ b/test/Hyphen.Sdk.Tests/Services/NetInfoTests.cs
@@ -60,6 +60,18 @@ public class NetInfoTests
 
 			Assert.Equal(expectedUri, netInfo.BaseUri.ToString());
 		}
+
+		[Theory]
+		[InlineData("http://localhost:12345/foo")]
+		[InlineData("http://localhost:12345/foo/")]
+		public void NormalizesTrailingSlashOnBaseUri(string baseUri)
+		{
+			options.BaseUri = new(baseUri);
+
+			var netInfo = new NetInfo(httpClientFactory, logger, Options.Create(options));
+
+			Assert.Equal("http://localhost:12345/foo/", netInfo.BaseUri.ToString());
+		}
 	}
 
 	public class CurrentIP : NetInfoTests

--- a/test/Hyphen.Sdk.Tests/Services/NetInfoTests.cs
+++ b/test/Hyphen.Sdk.Tests/Services/NetInfoTests.cs
@@ -76,6 +76,7 @@ public class NetInfoTests
 			var request = Assert.Single(messageHandler.Requests);
 			Assert.Equal(HttpMethod.Get, request.Method);
 			Assert.Equal("https://net.info/ip", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
 			Assert.Null(request.Body);
 			Assert.Equivalent(ip, response, strict: true);
 		}
@@ -155,6 +156,7 @@ public class NetInfoTests
 			var request = Assert.Single(messageHandler.Requests);
 			Assert.Equal(HttpMethod.Post, request.Method);
 			Assert.Equal("https://net.info/ip", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
 			Assert.Equal("""["1.2.3.4"]""", request.Body);
 			Assert.Equivalent(ip, response, strict: true);
 		}
@@ -244,6 +246,7 @@ public class NetInfoTests
 			var request = Assert.Single(messageHandler.Requests);
 			Assert.Equal(HttpMethod.Post, request.Method);
 			Assert.Equal("https://net.info/ip", request.Uri);
+			Assert.Equal("abc123", Assert.Single(request.Headers.GetValues("x-api-key")));
 			Assert.Equal("""["1.2.3.4","5.6.7.8"]""", request.Body);
 			Assert.Equivalent(ip1, response[0], strict: true);
 			Assert.Equivalent(ip2, response[1], strict: true);

--- a/test/Hyphen.Sdk.Tests/Types/Link/QrCodeResultTests.cs
+++ b/test/Hyphen.Sdk.Tests/Types/Link/QrCodeResultTests.cs
@@ -1,0 +1,43 @@
+using System.Text;
+using Hyphen.Sdk.Resources;
+
+namespace Hyphen.Sdk;
+
+public class QrCodeResultTests
+{
+	public class GetQrCodeBytes
+	{
+		[Fact]
+		public void UnknownHeader()
+		{
+			var qcr = new QrCodeResult { Id = "id", Link = new("http://localhost"), QrCode = "unknown" };
+
+			var ex = Record.Exception(qcr.GetQrCodeBytes);
+
+			Assert.IsType<InvalidOperationException>(ex);
+			Assert.Equal(HyphenSdkResources.Link_QrCodeInvalidFormat, ex.Message);
+		}
+
+		[Fact]
+		public void InvalidBase64Value()
+		{
+			var qcr = new QrCodeResult { Id = "id", Link = new("http://localhost"), QrCode = "data:image/png;base64,Hello World *$" };
+
+			var ex = Record.Exception(qcr.GetQrCodeBytes);
+
+			Assert.IsType<FormatException>(ex);
+		}
+
+		[Fact]
+		public void ValidBase64Value()
+		{
+			var helloWorldBytes = Encoding.UTF8.GetBytes("Hello, world");
+			var helloWorldBase64 = Convert.ToBase64String(helloWorldBytes);
+			var qcr = new QrCodeResult { Id = "id", Link = new("http://localhost"), QrCode = "data:image/png;base64," + helloWorldBase64 };
+
+			var result = qcr.GetQrCodeBytes();
+
+			Assert.Equal(helloWorldBytes, result);
+		}
+	}
+}

--- a/test/Hyphen.Sdk.Tests/Types/PagedParamsTests.cs
+++ b/test/Hyphen.Sdk.Tests/Types/PagedParamsTests.cs
@@ -13,6 +13,16 @@ public class PagedParamsTests
 			Assert.StartsWith("Page number must be a positive integer", argEx.Message);
 			Assert.Equal("PageNumber", argEx.ParamName);
 		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(42)]
+		public void ValidValues(int? pageNumber)
+		{
+			var ex = Record.Exception(() => new PagedParams { PageNumber = pageNumber });
+
+			Assert.Null(ex);
+		}
 	}
 
 	public class PageSize
@@ -27,6 +37,16 @@ public class PagedParamsTests
 			var argEx = Assert.IsType<ArgumentException>(ex);
 			Assert.StartsWith("Page size must be between 5 and 200", argEx.Message);
 			Assert.Equal("PageSize", argEx.ParamName);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(42)]
+		public void ValidValues(int? pageSize)
+		{
+			var ex = Record.Exception(() => new PagedParams { PageSize = pageSize });
+
+			Assert.Null(ex);
 		}
 	}
 }

--- a/test/Hyphen.Sdk.Tests/Types/PagedParamsTests.cs
+++ b/test/Hyphen.Sdk.Tests/Types/PagedParamsTests.cs
@@ -1,0 +1,32 @@
+namespace Hyphen.Sdk;
+
+public class PagedParamsTests
+{
+	public class PageNumber
+	{
+		[Fact]
+		public void GuardClause()
+		{
+			var ex = Record.Exception(() => new PagedParams { PageNumber = 0 });
+
+			var argEx = Assert.IsType<ArgumentException>(ex);
+			Assert.StartsWith("Page number must be a positive integer", argEx.Message);
+			Assert.Equal("PageNumber", argEx.ParamName);
+		}
+	}
+
+	public class PageSize
+	{
+		[Theory]
+		[InlineData(4)]
+		[InlineData(201)]
+		public void GuardClause(int value)
+		{
+			var ex = Record.Exception(() => new PagedParams { PageSize = value });
+
+			var argEx = Assert.IsType<ArgumentException>(ex);
+			Assert.StartsWith("Page size must be between 5 and 200", argEx.Message);
+			Assert.Equal("PageSize", argEx.ParamName);
+		}
+	}
+}

--- a/test/Hyphen.Sdk.Tests/Util/SpyHttpMessageHandler.cs
+++ b/test/Hyphen.Sdk.Tests/Util/SpyHttpMessageHandler.cs
@@ -1,8 +1,10 @@
+using System.Net.Http.Headers;
+
 namespace System.Net.Http;
 
 internal class SpyHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
 {
-	public List<(HttpMethod Method, string? Uri, string? Body)> Requests = [];
+	public List<(HttpMethod Method, HttpRequestHeaders Headers, string? Uri, string? Body)> Requests = [];
 
 	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 	{
@@ -11,7 +13,7 @@ internal class SpyHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessag
 				? await request.Content.ReadAsStringAsync(cancellationToken)
 				: null;
 
-		Requests.Add((request.Method, request.RequestUri?.ToString(), content));
+		Requests.Add((request.Method, request.Headers, request.RequestUri?.ToString(), content));
 		return handler(request);
 	}
 }


### PR DESCRIPTION
This introduces a new service interface (`ILink`) which can be used to manage short code links and their associated QR codes.